### PR TITLE
Feature #115/memory optimistic locking

### DIFF
--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -25,7 +25,7 @@ class MemcachedBackend:
             aiocache.settings.DEFAULT_CACHE_KWARGS.get("endpoint", self.DEFAULT_ENDPOINT)
         self.port = port or aiocache.settings.DEFAULT_CACHE_KWARGS.get("port", self.DEFAULT_PORT)
 
-    async def _get(self, key):
+    async def _get(self, key, watch=False):
         """
         Get a value from the cache. Returns default if not found.
 
@@ -52,7 +52,7 @@ class MemcachedBackend:
                 values.append(value)
         return values
 
-    async def _set(self, key, value, ttl=0):
+    async def _set(self, key, value, ttl=0, optimistic_lock=False):
         """
         Stores the value in the given key.
 
@@ -138,6 +138,15 @@ class MemcachedBackend:
             raise ValueError("MemcachedBackend doesnt support flushing by namespace")
         else:
             await self.client.flush_all()
+        return True
+
+    async def _watch(self, key):
+        """
+        Start watching a key
+
+        :param key: str
+        :returns: True
+        """
         return True
 
     async def _raw(self, command, *args, **kwargs):

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -12,7 +12,7 @@ class SimpleMemoryBackend:
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    async def _get(self, key):
+    async def _get(self, key, watch=False):
         """
         Get a value from the cache
 
@@ -30,7 +30,7 @@ class SimpleMemoryBackend:
         """
         return [SimpleMemoryBackend._cache.get(key) for key in keys]
 
-    async def _set(self, key, value, ttl=None):
+    async def _set(self, key, value, ttl=None, optimistic_lock=False):
         """
         Stores the value in the given key.
 
@@ -126,6 +126,15 @@ class SimpleMemoryBackend:
         else:
             SimpleMemoryBackend._cache = {}
             SimpleMemoryBackend._handlers = {}
+        return True
+
+    async def _watch(self, key):
+        """
+        Start watching a key
+
+        :param key: str
+        :returns: True
+        """
         return True
 
     async def _raw(self, command, *args, **kwargs):

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -1,13 +1,17 @@
 import asyncio
 import itertools
 import aioredis
-
 import aiocache
+
+from collections import defaultdict
+
+from aiocache.exceptions import WatchError
 
 
 class RedisBackend:
 
     pools = {}
+    watched_keys = defaultdict(set)
     DEFAULT_ENDPOINT = "127.0.0.1"
     DEFAULT_PORT = 6379
     DEFAULT_DB = 0
@@ -33,13 +37,16 @@ class RedisBackend:
         self.password = password or \
             aiocache.settings.DEFAULT_CACHE_KWARGS.get("password", self.DEFAULT_PASSWORD)
 
-    async def _get(self, key):
+    async def _get(self, key, watch=False):
         """
         Get a value from the cache
 
         :param key: str
         :returns: obj in key if found else None
         """
+
+        if watch:
+            await self._watch(key)
 
         with await self._connect() as redis:
             return await redis.get(key)
@@ -54,7 +61,7 @@ class RedisBackend:
         with await self._connect() as redis:
             return await redis.mget(*keys)
 
-    async def _set(self, key, value, ttl=None):
+    async def _set(self, key, value, ttl=None, optimistic_lock=False):
         """
         Stores the value in the given key.
 
@@ -63,8 +70,23 @@ class RedisBackend:
         :param ttl: int
         :returns: True
         """
+        if optimistic_lock is True:
+            return await self._set_optimistic_lock(key, value, ttl)
+
         with await self._connect() as redis:
             return await redis.set(key, value, expire=ttl)
+
+    async def _set_optimistic_lock(self, key, value, ttl=None):
+        if key in RedisBackend.watched_keys:
+            redis = RedisBackend.watched_keys[key].pop()
+        else:
+            redis = await (await self.create_pool()).acquire()
+        transaction = redis.multi_exec()
+        transaction.set(key, value, expire=ttl)
+        try:
+            return await transaction.execute()
+        except aioredis.errors.MultiExecError:
+            raise WatchError("Key {} was changed before current transaction".format(key))
 
     async def _multi_set(self, pairs, ttl=None):
         """
@@ -157,6 +179,17 @@ class RedisBackend:
                 await redis.flushdb()
         return True
 
+    async def _watch(self, key):
+        """
+        Start watching a key
+
+        :param key: str
+        :returns: True
+        """
+        with await self._connect() as redis:
+            RedisBackend.watched_keys[key].add(redis)
+            return await redis.watch(key)
+
     async def _raw(self, command, *args, **kwargs):
         """
         Executes a raw command using the underlying client of aioredis. It's under
@@ -167,22 +200,25 @@ class RedisBackend:
         with await self._connect() as redis:
             return await getattr(redis, command)(*args, **kwargs)
 
+    async def _connect(self):
+        pool_key, pool = self.get_pool()
+
+        if pool is None:
+            pool = await self.create_pool()
+            RedisBackend.pools[pool_key] = pool
+        return await pool
+
     def get_pool(self):
         pool_key = "{}{}{}{}{}{}".format(
             self.endpoint, self.port, getattr(self, "encoding", None),
             self.db, self.password, id(self._loop))
         return pool_key, RedisBackend.pools.get(pool_key)
 
-    async def _connect(self):
-        pool_key, pool = self.get_pool()
-
-        if pool is None:
-            pool = await aioredis.create_pool(
-                (self.endpoint, self.port),
-                encoding=getattr(self, "encoding", None),
-                db=self.db,
-                password=self.password,
-                loop=self._loop)
-            RedisBackend.pools[pool_key] = pool
-
-        return await pool
+    async def create_pool(self):
+        pool = await aioredis.create_pool(
+            (self.endpoint, self.port),
+            encoding=getattr(self, "encoding", None),
+            db=self.db,
+            password=self.password,
+            loop=self._loop, maxsize=1)
+        return pool

--- a/aiocache/exceptions.py
+++ b/aiocache/exceptions.py
@@ -1,0 +1,2 @@
+class WatchError(Exception):
+    pass

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -36,6 +36,7 @@ def reset_redis_pools(event_loop):
 @pytest.fixture
 def redis_cache(event_loop):
     cache = RedisCache(namespace="test", loop=event_loop)
+    cache.watched_keys.clear()
     yield cache
 
     event_loop.run_until_complete(cache.delete(pytest.KEY))

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -36,7 +36,7 @@ def reset_redis_pools(event_loop):
 @pytest.fixture
 def redis_cache(event_loop):
     cache = RedisCache(namespace="test", loop=event_loop)
-    cache.watched_keys.clear()
+    cache._watched_keys.clear()
     yield cache
 
     event_loop.run_until_complete(cache.delete(pytest.KEY))
@@ -50,6 +50,7 @@ def redis_cache(event_loop):
 @pytest.fixture
 def memory_cache(event_loop):
     cache = SimpleMemoryCache(namespace="test")
+    cache._watched_keys.clear()
     yield cache
 
     event_loop.run_until_complete(cache.delete(pytest.KEY))

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 
 from asynctest import CoroutineMock, MagicMock, patch
 
@@ -42,14 +43,19 @@ class FakePool:
     def __exit__(self, *args, **kwargs):
         pass
 
+    async def acquire(self):
+        return self.client
+
     def __call__(self):
         return self
 
 
 @pytest.fixture
 def redis(event_loop):
+    RedisBackend.watched_keys.clear()
     redis = RedisBackend()
     pool = FakePool()
+    redis.create_pool = CoroutineMock(side_effect=pool)
     redis._connect = pool
     yield redis, pool
 
@@ -125,6 +131,13 @@ class TestRedisBackend:
         pool.client.get.assert_called_with(pytest.KEY)
 
     @pytest.mark.asyncio
+    async def test_get_watch(self, redis):
+        cache, pool = redis
+        await cache._get(pytest.KEY, watch=True)
+        pool.client.watch.assert_called_with(pytest.KEY)
+        pool.client.get.assert_called_with(pytest.KEY)
+
+    @pytest.mark.asyncio
     async def test_set(self, redis):
         cache, pool = redis
         await cache._set(pytest.KEY, "value")
@@ -132,6 +145,15 @@ class TestRedisBackend:
 
         await cache._set(pytest.KEY, "value", ttl=1)
         pool.client.set.assert_called_with(pytest.KEY, "value", expire=1)
+
+    @pytest.mark.asyncio
+    async def test_set_optimistic_lock(self, redis):
+        cache, pool = redis
+        await cache._set(pytest.KEY, "value", optimistic_lock=True)
+
+        assert pool.client.multi_exec.call_count == 1
+        pool.transaction.set.assert_called_with(pytest.KEY, "value", expire=None)
+        assert pool.transaction.execute.call_count == 1
 
     @pytest.mark.asyncio
     async def test_multi_get(self, redis):
@@ -208,6 +230,19 @@ class TestRedisBackend:
         cache, pool = redis
         await cache._clear()
         assert pool.client.flushdb.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_watch(self, redis):
+        cache, pool = redis
+        await cache._watch(pytest.KEY)
+        pool.client.watch.assert_called_with(pytest.KEY)
+
+    @pytest.mark.asyncio
+    async def test_watch_tracks_connection(self, redis):
+        cache, pool = redis
+        cache._connect = CoroutineMock(side_effect=[FakePool(), FakePool()])
+        await asyncio.gather(cache._watch(pytest.KEY), cache._watch(pytest.KEY))
+        assert len(cache.watched_keys[pytest.KEY]) == 2
 
     @pytest.mark.asyncio
     async def test_raw(self, redis):


### PR DESCRIPTION
With this implementation there is no context with watching a key. If a task calls watch and another independent task calls the `set` with optimistic locking enabled, it will check with the last `watch` call value.

Still, this works for the race condition case of `cached` decorator. But needs a bit more investigation/thinking

PS: After thinking a bit more, lets leave it this way. The same problem will appear with redis, although the granularity is per connection, since we are working with a pool it could always happen that the independent process is using the same connection used to watch the key.