### PR TITLE
Timeout per function. Propagate it correctly with defaults.

### DIFF
--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -77,7 +77,7 @@ class MemcachedBackend:
             value = str.encode(value) if isinstance(value, str) else value
             tasks.append(asyncio.ensure_future(self.client.set(key, value, exptime=ttl or 0)))
 
-        asyncio.gather(*tasks)
+        await asyncio.gather(*tasks)
 
         return True
 

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -29,7 +29,8 @@ class RedisBackend:
         self.endpoint = endpoint or \
             aiocache.settings.DEFAULT_CACHE_KWARGS.get("endpoint", self.DEFAULT_ENDPOINT)
         self.port = port or aiocache.settings.DEFAULT_CACHE_KWARGS.get("port", self.DEFAULT_PORT)
-        self.db = db or aiocache.settings.DEFAULT_CACHE_KWARGS.get("db", self.DEFAULT_DB)
+        self.db = db if db is not None else \
+            aiocache.settings.DEFAULT_CACHE_KWARGS.get("db")
         self.password = password or \
             aiocache.settings.DEFAULT_CACHE_KWARGS.get("password", self.DEFAULT_PASSWORD)
 

--- a/tests/integration/test_cache_settings.py
+++ b/tests/integration/test_cache_settings.py
@@ -1,0 +1,29 @@
+import pytest
+import aiocache
+
+from aiocache import RedisCache
+
+
+@pytest.fixture(autouse=True)
+def reset_defaults():
+    aiocache.settings.set_from_dict({
+        "CACHE": {
+            "class": "aiocache.SimpleMemoryCache",
+        },
+        "SERIALIZER": {
+            "class": "aiocache.serializers.DefaultSerializer",
+        },
+        "PLUGINS": []
+    })
+
+
+class TestRedisSettings:
+    def test_cache_settings(self):
+        aiocache.settings.set_defaults(
+            class_=aiocache.RedisCache, endpoint="127.0.0.1", port=6379, timeout=10, db=1)
+        cache = RedisCache(db=0)
+
+        assert cache.endpoint == "127.0.0.1"
+        assert cache.port == 6379
+        assert cache.timeout == 10
+        assert cache.db == 0

--- a/tests/ut/test_cache.py
+++ b/tests/ut/test_cache.py
@@ -53,16 +53,39 @@ class TestAPI:
             assert await dummy() == []
 
     @pytest.mark.asyncio
-    async def test_timeout(self):
+    async def test_timeout_self(self):
         self = MagicMock()
         self.timeout = 0.002
 
         @API.timeout
-        async def dummy(self, *args, **kwargs):
+        async def dummy(self):
             await asyncio.sleep(0.005)
 
         with pytest.raises(asyncio.TimeoutError):
             await dummy(self)
+
+    @pytest.mark.asyncio
+    async def test_timeout_kwarg(self):
+        self = MagicMock()
+
+        @API.timeout
+        async def dummy(self):
+            await asyncio.sleep(0.005)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await dummy(self, timeout=0.002)
+
+    @pytest.mark.asyncio
+    async def test_timeout_self_kwarg(self):
+        self = MagicMock()
+        self.timeout = 5
+
+        @API.timeout
+        async def dummy(self):
+            await asyncio.sleep(0.005)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await dummy(self, timeout=0.003)
 
     @pytest.mark.asyncio
     async def test_plugins(self):


### PR DESCRIPTION
Also solved a bug where memcached multi_set wasn't waiting for
keys to be inserted.

Closes #163 and #162