### PR TITLE
Refactor settings module, breaking changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ pylint:
 ut:
 	pytest -sv tests/ut
 
+_integration:
+	pytest -sv tests/integration
+
+integration: dockerup _integration dockerdown
+
 _acceptance:
 	pytest -sv tests/acceptance
 
@@ -29,7 +34,7 @@ _functional:
 
 functional: dockerup _functional dockerdown
 
-test: syntax ut dockerup _acceptance _functional dockerdown
+test: syntax ut dockerup _integration _acceptance _functional dockerdown
 
 _release:
 	scripts/make_release

--- a/aiocache/__init__.py
+++ b/aiocache/__init__.py
@@ -1,6 +1,6 @@
-from aiocache.cache import SimpleMemoryCache, RedisCache, MemcachedCache
+from aiocache.settings import Settings as settings
 from aiocache.decorators import cached, multi_cached
-from aiocache import settings
+from aiocache.cache import SimpleMemoryCache, RedisCache, MemcachedCache
 
 
 __all__ = (

--- a/aiocache/cache.py
+++ b/aiocache/cache.py
@@ -3,10 +3,9 @@ import time
 import functools
 import asyncio
 
-import aiocache
-
-from aiocache.log import logger
+from aiocache import settings
 from aiocache.utils import get_cache_value_with_fallbacks
+from aiocache.log import logger
 from aiocache.backends import SimpleMemoryBackend, RedisBackend, MemcachedBackend
 
 
@@ -107,10 +106,10 @@ class BaseCache:
         self.plugins = plugins or self.get_default_plugins()
 
     def get_default_serializer(self):
-        return aiocache.settings.DEFAULT_SERIALIZER()
+        return settings.get_serializer_class()()
 
     def get_default_plugins(self):
-        return [plugin(**config) for plugin, config in aiocache.settings.DEFAULT_PLUGINS.items()]
+        return [plugin(**config) for plugin, config in settings._PLUGINS]
 
     @property
     def serializer(self):

--- a/aiocache/settings.py
+++ b/aiocache/settings.py
@@ -1,149 +1,230 @@
+"""
+This module is depended by many other modules for pulling the default settings. In order to avoid
+circular imports, this module must not depend on any other module from aiocache.
+"""
 import inspect
 
-from aiocache import SimpleMemoryCache
-from aiocache.log import logger
-from aiocache.cache import BaseCache
-from aiocache.utils import class_from_string
-from aiocache.serializers import DefaultSerializer
-from aiocache.plugins import BasePlugin
+
+def class_from_string(class_path):
+    class_name = class_path.split('.')[-1]
+    module_name = class_path.rstrip(class_name).rstrip(".")
+    return getattr(__import__(module_name, fromlist=[class_name]), class_name)
 
 
-DEFAULT_CACHE = SimpleMemoryCache
-DEFAULT_CACHE_KWARGS = {}
+class Settings:
 
-DEFAULT_SERIALIZER = DefaultSerializer
-DEFAULT_SERIALIZER_KWARGS = {}
+    __instance = None
+    _CACHE = "aiocache.SimpleMemoryCache"
+    _CACHE_KWARGS = {}
 
-DEFAULT_PLUGINS = {}
+    _SERIALIZER = "aiocache.serializers.DefaultSerializer"
+    _SERIALIZER_KWARGS = {}
 
+    _PLUGINS = {}
 
-def set_defaults(class_=SimpleMemoryCache, **kwargs):
-    """
-    Set the default settings for the cache. If within your project you are working with a Redis
-    backend, you can use it as::
+    def __new__(cls):
 
-        aiocache.settings.set_defaults(
-            class_="aiocache.RedisCache", endpoint="127.0.0.1", port=6379, namespace="test")
+        if cls.__instance is None:
+            cls.__instance = object.__new__(cls)
+        return cls.__instance
 
-    Once the call is done, all decorators and instances where those params are not specified, the
-    default ones will be picked. The class_ param accepts both str and class types.
-    """
-    if class_:
-        if isinstance(class_, str) and issubclass(class_from_string(class_), BaseCache):
-            globals()['DEFAULT_CACHE'] = class_from_string(class_)
-        elif inspect.isclass(class_) and issubclass(class_, BaseCache):
-            globals()['DEFAULT_CACHE'] = class_
-        else:
-            raise ValueError(
-                "DEFAULT_CACHE must be a str or class subclassing aiocache.cache.BaseCache")
-    globals()['DEFAULT_CACHE_KWARGS'] = kwargs
+    @classmethod
+    def get_cache_class(cls):
+        """
+        Get the default class configured
+        :returns: class set as default cache
+        """
+        if isinstance(cls._CACHE, str):
+            return class_from_string(cls._CACHE)
+        return cls._CACHE
 
+    @classmethod
+    def get_cache_args(cls):
+        """
+        Get the **kwargs configured for the default cache
+        :returns: dict containing the default args
+        """
+        return cls._CACHE_KWARGS
 
-def set_default_serializer(class_=DefaultSerializer, **kwargs):
-    """
-    Set the default settings for the serializer. If within your project you are working with
-    json objects, you may want to call it as::
+    @classmethod
+    def get_serializer_class(cls):
+        """
+        Get the default serializer configured
+        :returns: class set as default serializer
+        """
+        if isinstance(cls._SERIALIZER, str):
+            return class_from_string(cls._SERIALIZER)
+        return cls._SERIALIZER
 
-        aiocache.settings.set_default_serializer(
-            class_="aiocache.serializers.JsonSerializer")
+    @classmethod
+    def get_serializer_args(cls):
+        """
+        Get the **kwargs configured for the default serializer
+        :returns: dict containing the default args
+        """
+        return cls._SERIALIZER_KWARGS
 
-    Once the call is done, all decorators and instances where serializer params are not specified,
-    the default ones will be picked. The class_ param accepts both str and class types.
+    @classmethod
+    def get_plugins_class(cls):
+        """
+        Get the default plugins classes configured
+        :returns: iterable of classes
+        """
+        return cls._PLUGINS.keys()
 
-    If you define your own serializer, you can also set is a default and pass the desired extra
-    params through this call.
-    """
-    if class_:
-        if isinstance(class_, str) and issubclass(class_from_string(class_), DefaultSerializer):
-            globals()['DEFAULT_SERIALIZER'] = class_from_string(class_)
-        elif inspect.isclass(class_) and issubclass(class_, DefaultSerializer):
-            globals()['DEFAULT_SERIALIZER'] = class_
-        else:
-            raise ValueError(
-                "DEFAULT_SERIALIZER must be a str or class \
-                subclassing aiocache.serializers.DefaultSerializer")
-    globals()['DEFAULT_SERIALIZER_KWARGS'] = kwargs
+    @classmethod
+    def get_plugins_args(cls):
+        """
+        Get the **kwargs configured for each plugin. Order matches with
+        the list returned by ``get_plugins_class``.
+        """
+        return cls._PLUGINS.values()
 
-
-def set_default_plugins(config):
-    """
-    Set the default settings for the plugins. If within your project you are working with a
-    custom plugin, you may want to call it as::
-
-        aiocache.settings.set_default_plugins([
-            {
-                'class': MyPlugin,
-            },
-            {
-                'class': 'my_module.OtherPlugin',
-                'arg': 1
-            }
-        })
-
-    Once the call is done, all decorators and instances where plugin params are not specified,
-    the default ones will be picked. The class param accepts both str and class types.
-
-    If you define your own plugin, you can also set is a default and pass the desired extra
-    params through this call.
-    """
-    new_plugins = {}
-    for plugin in config:
-        class_ = plugin.pop('class')
-        if isinstance(class_, str) and issubclass(class_from_string(class_), BasePlugin):
-            new_plugins[class_from_string(class_)] = plugin
-        elif inspect.isclass(class_) and issubclass(class_, BasePlugin):
-            new_plugins[class_] = plugin
-        else:
-            logger.warning(
-                "%s must be a str or class subclassing aiocache.plugins.BasePlugin", class_)
-
-    globals()['DEFAULT_PLUGINS'] = new_plugins
-
-
-def get_defaults():
-    return {
-        "DEFAULT_CACHE": DEFAULT_CACHE,
-        "DEFAULT_CACHE_KWARGS": DEFAULT_CACHE_KWARGS,
-        "DEFAULT_SERIALIZER": DEFAULT_SERIALIZER,
-        "DEFAULT_SERIALIZER_KWARGS": DEFAULT_SERIALIZER_KWARGS,
-        "DEFAULT_PLUGINS": DEFAULT_PLUGINS,
-    }
-
-
-def set_from_dict(config):
-    """
-    Set the default settings for aiocache from a dict-like structure. The structure is the
-    following::
-
-        {
-            "CACHE": {
-                "class": "aiocache.RedisCache",
-                "endpoint": "127.0.0.1",
-                "port": 6379
-            },
-            "SERIALIZER": {
-                "class": "aiocache.serializers.DefaultSerializer"
-            },
-            "PLUGINS": [
-                {
-                    "class": "aiocache.plugins.BasePlugin"
-                }
-            ]
+    @classmethod
+    def get_defaults(cls):
+        return {
+            "CACHE": cls.get_cache_class(),
+            "CACHE_KWARGS": cls.get_cache_args(),
+            "SERIALIZER": cls.get_serializer_class(),
+            "SERIALIZER_KWARGS": cls.get_serializer_args(),
+            "PLUGINS": cls._PLUGINS,
         }
 
-    Of course you can set your own classes there. Any extra parameter you put in the dict will be
-    used for new instantiations if those are not set explicitly when calling it. The class param
-    accepts both str and class types.
+    @classmethod
+    def set_cache(cls, cache, **kwargs):
+        """
+        Set default cache and its config. If within your project you are working with a Redis
+        backend, you can use it as::
 
-    All keys in the config are optional, if they are not passed the previous defaults will be kept.
-    """
-    if "CACHE" in config:
-        class_ = config['CACHE'].pop("class", None)
-        set_defaults(class_=class_, **config['CACHE'])
+            aiocache.settings.set_cache(
+                "aiocache.RedisCache", endpoint="127.0.0.1", port=6379, namespace="test")
 
-    if "SERIALIZER" in config:
-        class_ = config['SERIALIZER'].pop("class", None)
-        set_default_serializer(class_=class_, **config['SERIALIZER'])
+        Once the call is done, all decorators and instances where those params are not specified,
+        the default ones will be picked. The cache param accepts both str and class types.
 
-    if "PLUGINS" in config:
-        set_default_plugins(config=config['PLUGINS'])
+        The kwargs are overridden in every call. If you pass empty kwargs, defaults will be cleared
+        despite that there were values before.
+        """
+        if isinstance(cache, str) and issubclass(
+                class_from_string(cache), class_from_string("aiocache.cache.BaseCache")):
+            cls._CACHE = class_from_string(cache)
+        elif inspect.isclass(cache) and issubclass(
+                cache, class_from_string("aiocache.cache.BaseCache")):
+            cls._CACHE = cache
+        else:
+            raise ValueError(
+                "Cache '%s' must be a str or class subclassing aiocache.cache.BaseCache" % cache)
+        cls._CACHE_KWARGS = kwargs
+
+    @classmethod
+    def set_serializer(cls, serializer, **kwargs):
+        """
+        Set default serializer and its config. If within your project you are working with
+        json objects, you may want to call it as::
+
+            aiocache.settings.set_serializer(
+                "aiocache.serializers.JsonSerializer")
+
+        Once the call is done, all decorators and instances where serializer params are
+        not specified, the default ones will be picked. The serializer param accepts both str
+        and class types.
+
+        If you define your own serializer, you can also set it as default and pass the desired extra
+        params through this call.
+
+        The kwargs are overridden in every call. If you pass empty kwargs, defaults will be cleared
+        despite that there were values before.
+        """
+        if isinstance(serializer, str) and issubclass(
+                class_from_string(
+                    serializer), class_from_string("aiocache.serializers.DefaultSerializer")):
+            cls._SERIALIZER = class_from_string(serializer)
+        elif inspect.isclass(serializer) and issubclass(
+                serializer, class_from_string("aiocache.serializers.DefaultSerializer")):
+            cls._SERIALIZER = serializer
+        else:
+            raise ValueError(
+                "Serializer '%s' must be a str or class \
+                subclassing aiocache.serializers.DefaultSerializer" % serializer)
+        cls._SERIALIZER_KWARGS = kwargs
+
+    @classmethod
+    def set_plugins(cls, config):
+        """
+        Set the default plugins and their config. If within your project you are working with a
+        custom plugin, you may want to call it as::
+
+            settings.set_plugins([
+                {
+                    'class': MyPlugin,
+                },
+                {
+                    'class': 'my_module.OtherPlugin',
+                    'arg': 1
+                }
+            })
+
+        Once the call is done, all decorators and instances where plugin params are not specified,
+        the default ones will be picked. The class param accepts both str and class types.
+
+        If you define your own plugin, you can also set is a default and pass the desired extra
+        params through this call.
+
+        The kwargs are overridden in every call. If you pass empty kwargs, defaults will be cleared
+        despite that there were values before.
+        """
+        new_plugins = {}
+        for plugin in config:
+            class_ = plugin.pop('class')
+            if isinstance(class_, str) and issubclass(
+                    class_from_string(class_), class_from_string("aiocache.plugins.BasePlugin")):
+                new_plugins[class_from_string(class_)] = plugin
+            elif inspect.isclass(class_) and issubclass(
+                    class_, class_from_string("aiocache.plugins.BasePlugin")):
+                new_plugins[class_] = plugin
+            else:
+                raise ValueError(
+                    "Plugin '%s' must be a str or class"
+                    "subclassing aiocache.plugins.BasePlugin" % class_)
+
+        cls._PLUGINS = new_plugins
+
+    @classmethod
+    def set_config(cls, config):
+        """
+        Set the default settings for aiocache from a dict-like structure. The structure is the
+        following::
+
+            {
+                "CACHE": {
+                    "class": "aiocache.RedisCache",
+                    "endpoint": "127.0.0.1",
+                    "port": 6379
+                },
+                "SERIALIZER": {
+                    "class": "aiocache.serializers.DefaultSerializer"
+                },
+                "PLUGINS": [
+                    {
+                        "class": "aiocache.plugins.BasePlugin"
+                    }
+                ]
+            }
+
+        Of course you can set your own classes there. Any extra parameter you put in the
+        dict will be used for new instantiations if those are not set explicitly when calling it.
+        The class param accepts both str and class types.
+
+        All keys in the config are optional, if they are not passed the previous defaults will
+        be kept.
+        """
+        if "CACHE" in config:
+            class_ = config['CACHE'].pop("class", None)
+            cls.set_cache(class_, **config['CACHE'])
+
+        if "SERIALIZER" in config:
+            class_ = config['SERIALIZER'].pop("class", None)
+            cls.set_serializer(class_, **config['SERIALIZER'])
+
+        if "PLUGINS" in config:
+            cls.set_plugins(config=config['PLUGINS'])

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,50 @@
+..  _settings:
+
+Settings
+========
+
+Sometimes you just want to use the same settings all over your project. To do so, some helpers are provided like ``set_cache``, ``set_serializer``, ``set_plugins``.
+
+All cache instances and decorators use the settings modules to pull values in case they are not passed explicitly. For example, imagine you do the following:
+
+.. code-block:: python
+
+    >>> from aiocache import settings, RedisCache
+    >>> settings.set_cache(RedisCache, endpoint="127.0.0.1")
+    >>> RedisCache(port=123)
+    RedisCache (127.0.0.1:123)
+    >>> RedisCache(endpoint="192.168.1.10", port=8379)
+    RedisCache (192.168.1.10:8379)
+
+Now let's see a case where behavior may be unexpected and see why it behaves this way:
+
+.. code-block:: python
+
+  >>> from aiocache import MemcachedCache, RedisCache, settings
+  2017-04-12 23:34:39,115 WARNING aiocache.log(13) | cPickle module not found, using pickle
+  >>> settings.set_cache(RedisCache, endpoint="192.168.1.10", port=8379)
+  >>> MemcachedCache()
+  MemcachedCache (127.0.0.1:11211)
+
+In the previous code, the default endpoint and port are not applied when creating the ``MemcachedCache`` instance because the default cache is a ``RedisCache`` and the defaults only apply if the class being instantiated is that class or a subclass.
+
+.. automodule:: aiocache.settings
+  :members: set_cache, set_serializer, set_plugins
+
+If you have many custom settings that you want to configure globally, it can be tedious to pick all of them from config file and forward them to the shown helpers. For these cases, the ``set_config`` can be useful:
+
+.. automodule:: aiocache.settings
+  :members: set_config
+
+If you need to know the current default configuration for aiocache, use ``get_defaults`` as
+
+.. code-block:: python
+
+    >>> import pprint
+    >>> from aiocache import settings
+    >>> pprint.pprint(settings.get_defaults())
+    {'CACHE': <class 'aiocache.cache.SimpleMemoryCache'>,
+     'CACHE_KWARGS': {},
+     'PLUGINS': {},
+     'SERIALIZER': <class 'aiocache.serializers.DefaultSerializer'>,
+     'SERIALIZER_KWARGS': {}}

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,7 +5,7 @@ Installation and Usage
 Installing
 ----------
 
-You just need to do a ``pip install aiocache``.
+Do ``pip install aiocache``.
 
 
 Caches
@@ -35,35 +35,6 @@ Here we are using the :ref:`simplememorycache` but you can use any other listed 
   - ``delete``: Deletes key and returns number of deleted items.
   - ``clear``: Clears the items stored.
   - ``raw``: Executes the specified command using the underlying client.
-
-
-Configuring project default settings
-------------------------------------
-
-  DISCLAIMER: The following utilities are using a globals-like anti pattern. If your project has an approach for dependency injection or using singletons use them please.
-
-Sometimes you just want to use the same settings all over your project. To do so, some helpers are provided like ``set_defaults``, ``set_default_serializer``, ``set_default_plugins``:
-
-.. automodule:: aiocache.settings
-  :members: set_defaults, set_default_serializer, set_default_plugins
-
-If you have many custom settings that you want to configure globally, it can be tedious to pick all of them from config file and forward them to the shown helpers. For these cases, the ``set_from_dict`` can give you a hand:
-
-.. automodule:: aiocache.settings
-  :members: set_from_dict
-
-If you need to know the current default configuration for your project, you can always use the ``get_defaults`` as
-
-.. code-block:: python
-
-    >>> import pprint
-    >>> import aiocache
-    >>> pprint.pprint(aiocache.settings.get_defaults())
-    {'DEFAULT_CACHE': <class 'aiocache.cache.SimpleMemoryCache'>,
-     'DEFAULT_CACHE_KWARGS': {},
-     'DEFAULT_PLUGINS': {},
-     'DEFAULT_SERIALIZER': <class 'aiocache.serializers.DefaultSerializer'>,
-     'DEFAULT_SERIALIZER_KWARGS': {}}
 
 
 Decorators

--- a/examples/config_default_cache.py
+++ b/examples/config_default_cache.py
@@ -7,11 +7,8 @@ from aiocache import cached, RedisCache
 
 Result = namedtuple('Result', "content, status")
 
-aiocache.settings.set_defaults(
-    class_="aiocache.RedisCache")
-
-aiocache.settings.set_default_serializer(
-    class_="aiocache.serializers.PickleSerializer")
+aiocache.settings.set_cache("aiocache.RedisCache")
+aiocache.settings.set_serializer("aiocache.serializers.PickleSerializer")
 
 
 @cached(ttl=10, key="key", namespace="main")

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,8 +1,6 @@
 import pytest
 
-import aiocache
-
-from aiocache import SimpleMemoryCache, RedisCache, MemcachedCache
+from aiocache import SimpleMemoryCache, RedisCache, MemcachedCache, settings
 from aiocache.backends import RedisBackend
 
 
@@ -15,7 +13,7 @@ def pytest_namespace():
 
 @pytest.fixture(autouse=True)
 def reset_defaults():
-    aiocache.settings.set_from_dict({
+    settings.set_config({
         "CACHE": {
             "class": "aiocache.SimpleMemoryCache",
         },

--- a/tests/integration/test_cache_settings.py
+++ b/tests/integration/test_cache_settings.py
@@ -1,12 +1,11 @@
 import pytest
-import aiocache
 
-from aiocache import RedisCache
+from aiocache import RedisCache, settings
 
 
 @pytest.fixture(autouse=True)
 def reset_defaults():
-    aiocache.settings.set_from_dict({
+    settings.set_config({
         "CACHE": {
             "class": "aiocache.SimpleMemoryCache",
         },
@@ -19,8 +18,8 @@ def reset_defaults():
 
 class TestRedisSettings:
     def test_cache_settings(self):
-        aiocache.settings.set_defaults(
-            class_=aiocache.RedisCache, endpoint="127.0.0.1", port=6379, timeout=10, db=1)
+        settings.set_cache(
+            RedisCache, endpoint="127.0.0.1", port=6379, timeout=10, db=1)
         cache = RedisCache(db=0)
 
         assert cache.endpoint == "127.0.0.1"

--- a/tests/ut/backends/test_memcached.py
+++ b/tests/ut/backends/test_memcached.py
@@ -9,14 +9,13 @@ from aiocache.backends import MemcachedBackend
 
 @pytest.fixture
 def set_settings():
-    settings.DEFAULT_CACHE_KWARGS = {
-        'endpoint': "endpoint",
-        'port': "port",
-    }
-    settings.DEFAULT_CACHE = MemcachedCache
+    settings.set_cache(
+        MemcachedCache,
+        endpoint="endpoint",
+        port="port",
+    )
     yield
-    settings.DEFAULT_CACHE = SimpleMemoryCache
-    settings.DEFAULT_CACHE_KWARGS = {}
+    settings.set_cache(SimpleMemoryCache)
 
 
 @pytest.fixture
@@ -55,7 +54,7 @@ class TestMemcachedBackend:
         assert redis_backend.port == "port"
 
     def test_setup_default_ignored_wrong_class(self, set_settings):
-        settings.DEFAULT_CACHE = str
+        settings._CACHE = str
 
         redis_backend = MemcachedBackend()
         assert redis_backend.endpoint == "127.0.0.1"

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -8,18 +8,17 @@ from aiocache.backends import RedisBackend
 
 @pytest.fixture
 def set_settings():
-    settings.DEFAULT_CACHE_KWARGS = {
-        'endpoint': "endpoint",
-        'port': "port",
-        'password': "pass",
-        'db': 2,
-        'pool_min_size': 2,
-        'pool_max_size': 20
-    }
-    settings.DEFAULT_CACHE = RedisCache
+    settings.set_cache(
+        RedisCache,
+        endpoint="endpoint",
+        port="port",
+        password="pass",
+        db=2,
+        pool_min_size=2,
+        pool_max_size=20
+    )
     yield
-    settings.DEFAULT_CACHE = SimpleMemoryCache
-    settings.DEFAULT_CACHE_KWARGS = {}
+    settings.set_cache(SimpleMemoryCache)
 
 
 class FakePool:
@@ -101,7 +100,7 @@ class TestRedisBackend:
         assert redis_backend.pool_max_size == 6
 
     def test_setup_default_ignored_wrong_class(self, set_settings):
-        settings.DEFAULT_CACHE = str
+        settings._CACHE = str
 
         redis_backend = RedisBackend()
         assert redis_backend.endpoint == "127.0.0.1"

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -1,8 +1,7 @@
 import pytest
 import asynctest
 
-import aiocache
-
+from aiocache import settings
 from aiocache.cache import RedisCache, BaseCache, MemcachedCache
 from aiocache.plugins import BasePlugin
 from aiocache.serializers import DefaultSerializer
@@ -16,13 +15,8 @@ def pytest_namespace():
 
 
 @pytest.fixture(autouse=True)
-def disable_logs(mocker):
-    mocker.patch("aiocache.cache.logger")
-
-
-@pytest.fixture(autouse=True)
-def reset_defaults():
-    aiocache.settings.set_from_dict({
+def reset_settings():
+    settings.set_config({
         "CACHE": {
             "class": "aiocache.SimpleMemoryCache",
         },
@@ -31,6 +25,11 @@ def reset_defaults():
         },
         "PLUGINS": []
     })
+
+
+@pytest.fixture(autouse=True)
+def disable_logs(mocker):
+    mocker.patch("aiocache.cache.logger")
 
 
 class MockCache(BaseCache):

--- a/tests/ut/test_cache.py
+++ b/tests/ut/test_cache.py
@@ -2,11 +2,10 @@ import os
 import pytest
 import asyncio
 import asynctest
-import aiocache
 
 from unittest.mock import patch, MagicMock, ANY
 
-from aiocache import SimpleMemoryCache, MemcachedCache
+from aiocache import SimpleMemoryCache, MemcachedCache, settings
 from aiocache.cache import BaseCache, API
 
 
@@ -330,7 +329,7 @@ class TestCache:
 
     @pytest.fixture
     def set_test_namespace(self):
-        aiocache.settings.DEFAULT_CACHE_KWARGS = {"namespace": "test"}
+        settings._CACHE_KWARGS = {"namespace": "test"}
 
     @pytest.mark.parametrize("namespace, expected", (
         [None, "test" + pytest.KEY],
@@ -345,9 +344,9 @@ class TestRedisCache:
 
     @pytest.fixture(autouse=True)
     def redis_defaults(self):
-        aiocache.settings.set_defaults(class_="aiocache.RedisCache")
+        settings.set_cache("aiocache.RedisCache")
         yield
-        aiocache.settings.set_defaults(class_="aiocache.SimpleMemoryCache")
+        settings.set_cache("aiocache.SimpleMemoryCache")
 
     @pytest.mark.parametrize("namespace, expected", (
         [None, "test:" + pytest.KEY],
@@ -371,9 +370,9 @@ class TestMemcachedCache:
 
     @pytest.fixture(autouse=True)
     def memcached_defaults(self):
-        aiocache.settings.set_defaults(class_="aiocache.MemcachedCache")
+        settings.set_cache("aiocache.MemcachedCache")
         yield
-        aiocache.settings.set_defaults(class_="aiocache.MemcachedCache")
+        settings.set_cache("aiocache.MemcachedCache")
 
     def test_inheritance(self):
         assert isinstance(MemcachedCache(), BaseCache)
@@ -392,4 +391,4 @@ class TestMemcachedCache:
 
 @pytest.fixture
 def set_test_namespace():
-    aiocache.settings.DEFAULT_CACHE_KWARGS = {"namespace": "test"}
+    settings._CACHE_KWARGS = {"namespace": "test"}

--- a/tests/ut/test_decorators.py
+++ b/tests/ut/test_decorators.py
@@ -6,6 +6,7 @@ import asynctest
 from unittest import mock
 
 from aiocache import cached, multi_cached, SimpleMemoryCache
+from aiocache.decorators import _get_args_dict
 from aiocache.backends import SimpleMemoryBackend
 
 
@@ -280,3 +281,19 @@ class TestMultiCachedDecorator:
 
         with pytest.raises(ValueError):
             await cached_decorator(raise_exception)(keys=[])
+
+
+def test_get_args_dict():
+
+    async def arg_return_dict(keys, dummy=None):
+        ret = {}
+        for value, key in enumerate(keys or ['a', 'd', 'z', 'y']):
+            ret[key] = value
+        return ret
+
+    args = ({'b', 'a'},)
+
+    assert _get_args_dict(arg_return_dict, args, {}) == {'dummy': None, 'keys': {'a', 'b'}}
+    assert _get_args_dict(arg_return_dict, args, {'dummy': 'dummy'}) == \
+        {'dummy': 'dummy', 'keys': {'a', 'b'}}
+    assert _get_args_dict(arg_return_dict, [], {'dummy': 'dummy'}) == {'dummy': 'dummy'}

--- a/tests/ut/test_settings.py
+++ b/tests/ut/test_settings.py
@@ -1,26 +1,175 @@
 import pytest
 import aiocache
 
-from aiocache import SimpleMemoryCache
+from aiocache import SimpleMemoryCache, settings
 from aiocache.serializers import DefaultSerializer
 from aiocache.plugins import BasePlugin
 
 
 class TestSettings:
 
+    def test_settings_singleton(self):
+        assert settings() is settings()
+
     def test_default_settings(self):
-        assert aiocache.settings.DEFAULT_CACHE == SimpleMemoryCache
-        assert aiocache.settings.DEFAULT_CACHE_KWARGS == {}
+        assert settings._CACHE == SimpleMemoryCache
+        assert settings._CACHE_KWARGS == {}
 
-        assert aiocache.settings.DEFAULT_SERIALIZER == DefaultSerializer
-        assert aiocache.settings.DEFAULT_SERIALIZER_KWARGS == {}
+        assert settings._SERIALIZER == DefaultSerializer
+        assert settings._SERIALIZER_KWARGS == {}
 
-        assert aiocache.settings.DEFAULT_PLUGINS == {}
+        assert settings._PLUGINS == {}
 
-    def test_set_from_dict_str(self):
-        config = {
+    def test_get_cache_class(self):
+        assert settings.get_cache_class() == SimpleMemoryCache
+
+    def test_get_cache_class_when_str(self):
+        settings._CACHE = "aiocache.SimpleMemoryCache"
+        assert settings.get_cache_class() == SimpleMemoryCache
+
+    def test_get_cache_args(self):
+        assert settings.get_cache_args() == {}
+
+    def test_get_serializer(self):
+        assert settings.get_serializer_class() == DefaultSerializer
+
+    def test_get_serializer_when_str(self):
+        settings._SERIALIZER = "aiocache.serializers.DefaultSerializer"
+        assert settings.get_serializer_class() == DefaultSerializer
+
+    def test_get_serializer_args(self):
+        assert settings.get_serializer_args() == {}
+
+    def test_get_plugins(self):
+        assert list(settings.get_plugins_class()) == []
+
+    def test_get_plugins_args(self):
+        assert list(settings.get_plugins_args()) == []
+
+    def test_set_cache_without_arg(self):
+        with pytest.raises(TypeError):
+            settings.set_cache(
+                endpoint="127.0.0.1", port=6379)
+
+    def test_set_cache_no_kwargs(self):
+        settings.set_cache(
+            "aiocache.RedisCache", endpoint="127.0.0.1", port=6379)
+        settings.set_cache(
+            "aiocache.RedisCache")
+
+        assert settings._CACHE_KWARGS == {}
+
+    def test_set_cache_str(self):
+        settings.set_cache(
+            "aiocache.RedisCache", endpoint="127.0.0.1", port=6379)
+
+        assert settings._CACHE == aiocache.RedisCache
+        assert settings._CACHE_KWARGS == {"endpoint": "127.0.0.1", "port": 6379}
+
+    def test_set_cache_str_fail(self):
+        with pytest.raises(ValueError):
+            settings.set_cache(
+                "aiocache.serializers.DefaultSerializer", endpoint="127.0.0.1", port=6379)
+
+    def test_set_cache_class(self):
+        settings.set_cache(
+            aiocache.RedisCache, endpoint="127.0.0.1", port=6379)
+
+        assert settings._CACHE == aiocache.RedisCache
+        assert settings._CACHE_KWARGS == {"endpoint": "127.0.0.1", "port": 6379}
+
+    def test_set_cache_class_fail(self):
+        with pytest.raises(ValueError):
+            settings.set_cache(
+                DefaultSerializer, endpoint="127.0.0.1", port=6379)
+
+    def test_set_serializer_without_arg(self):
+        with pytest.raises(TypeError):
+            settings.set_serializer()
+
+    def test_set_serializer_no_kwargs(self):
+        settings.set_serializer(
+            "aiocache.serializers.DefaultSerializer", endpoint="127.0.0.1", port=6379)
+        settings.set_serializer(
+            "aiocache.serializers.DefaultSerializer")
+
+        assert settings._SERIALIZER_KWARGS == {}
+
+    def test_set_serializer_str(self):
+        settings.set_serializer(
+            "aiocache.serializers.DefaultSerializer", random_attr="random_value")
+
+        assert settings._SERIALIZER == DefaultSerializer
+        assert settings._SERIALIZER_KWARGS == {"random_attr": "random_value"}
+
+    def test_set_serializer_str_fail(self):
+        with pytest.raises(ValueError):
+            settings.set_serializer(
+                "aiocache.RedisCache", random_attr="random_value")
+
+    def test_set_serializer_class(self):
+        settings.set_serializer(
+            DefaultSerializer, random_attr="random_value")
+
+        assert settings._SERIALIZER == DefaultSerializer
+        assert settings._SERIALIZER_KWARGS == {"random_attr": "random_value"}
+
+    def test_set_serializer_class_fail(self):
+        with pytest.raises(ValueError):
+            settings.set_serializer(
+                aiocache.RedisCache, random_attr="random_value")
+
+    def test_set_plugins_str(self):
+        settings.set_plugins(
+            [{"class": "aiocache.plugins.BasePlugin", "max_keys": 2}])
+
+        assert settings._PLUGINS == {
+            BasePlugin: {"max_keys": 2}}
+
+    def test_set_plugin_no_kwargs(self):
+        settings.set_plugins(
+            [{"class": "aiocache.plugins.BasePlugin", "max_keys": 2}])
+        settings.set_plugins(
+            [{"class": "aiocache.plugins.BasePlugin"}])
+
+        assert settings._PLUGINS == {BasePlugin: {}}
+
+    def test_set_plugins_str_fail(self):
+        with pytest.raises(ValueError):
+            settings.set_plugins(
+                [{"class": "aiocache.RedisCache", "random_attr": "random_value"}])
+
+    def test_set_plugins_class(self):
+        settings.set_plugins(
+            [{"class": BasePlugin, "random_attr": "random_value"}])
+
+        assert settings._PLUGINS == {
+            BasePlugin: {"random_attr": "random_value"}}
+
+    def test_set_plugins_class_fail(self):
+        with pytest.raises(ValueError):
+            settings.set_plugins(
+                [{"class": aiocache.RedisCache, "random_attr": "random_value"}])
+
+    def test_set_empty_config(self):
+        old_settings = settings.get_defaults()
+        settings.set_config({})
+        assert settings.get_defaults() == old_settings
+
+    def test_set_config_reset_kwargs(self):
+        settings.set_config({
             "CACHE": {
                 "class": "aiocache.RedisCache",
+                "endpoint": "123123"}})
+        settings.set_config({
+            "CACHE": {
+                "class": "aiocache.RedisCache"}})
+        assert settings.get_cache_args() == {}
+
+    def test_set_config(self):
+        config = {
+            "CACHE": {
+                "class": aiocache.RedisCache,
                 "endpoint": "127.0.0.1",
                 "port": 6379
             },
@@ -30,101 +179,27 @@ class TestSettings:
             },
             "PLUGINS": [
                 {
-                    "class": "aiocache.plugins.BasePlugin",
+                    "class": BasePlugin,
                     "max_keys": 2
                 }
             ]
         }
 
-        aiocache.settings.set_from_dict(config)
+        settings.set_config(config)
 
-        assert aiocache.settings.DEFAULT_CACHE == aiocache.RedisCache
-        assert aiocache.settings.DEFAULT_CACHE_KWARGS == {"endpoint": "127.0.0.1", "port": 6379}
+        assert settings._CACHE == aiocache.RedisCache
+        assert settings._CACHE_KWARGS == {"endpoint": "127.0.0.1", "port": 6379}
 
-        assert aiocache.settings.DEFAULT_SERIALIZER == DefaultSerializer
-        assert aiocache.settings.DEFAULT_SERIALIZER_KWARGS == {"random_attr": "random_value"}
+        assert settings._SERIALIZER == DefaultSerializer
+        assert settings._SERIALIZER_KWARGS == {"random_attr": "random_value"}
 
-        assert aiocache.settings.DEFAULT_PLUGINS == {BasePlugin: {"max_keys": 2}}
-
-    def test_set_defaults_str(self):
-        aiocache.settings.set_defaults(
-            class_="aiocache.RedisCache", endpoint="127.0.0.1", port=6379)
-
-        assert aiocache.settings.DEFAULT_CACHE == aiocache.RedisCache
-        assert aiocache.settings.DEFAULT_CACHE_KWARGS == {"endpoint": "127.0.0.1", "port": 6379}
-
-    def test_set_defaults_str_fail(self):
-        with pytest.raises(ValueError):
-            aiocache.settings.set_defaults(
-                class_="aiocache.serializers.DefaultSerializer", endpoint="127.0.0.1", port=6379)
-
-    def test_set_defaults_class(self):
-        aiocache.settings.set_defaults(
-            class_=aiocache.RedisCache, endpoint="127.0.0.1", port=6379)
-
-        assert aiocache.settings.DEFAULT_CACHE == aiocache.RedisCache
-        assert aiocache.settings.DEFAULT_CACHE_KWARGS == {"endpoint": "127.0.0.1", "port": 6379}
-
-    def test_set_defaults_class_fail(self):
-        with pytest.raises(ValueError):
-            aiocache.settings.set_defaults(
-                class_=DefaultSerializer, endpoint="127.0.0.1", port=6379)
-
-    def test_set_default_serializer_str(self):
-        aiocache.settings.set_default_serializer(
-            class_="aiocache.serializers.DefaultSerializer", random_attr="random_value")
-
-        assert aiocache.settings.DEFAULT_SERIALIZER == DefaultSerializer
-        assert aiocache.settings.DEFAULT_SERIALIZER_KWARGS == {"random_attr": "random_value"}
-
-    def test_set_default_serializer_str_fail(self):
-        with pytest.raises(ValueError):
-            aiocache.settings.set_default_serializer(
-                class_="aiocache.RedisCache", random_attr="random_value")
-
-    def test_set_default_serializer_class(self):
-        aiocache.settings.set_default_serializer(
-            class_=DefaultSerializer, random_attr="random_value")
-
-        assert aiocache.settings.DEFAULT_SERIALIZER == DefaultSerializer
-        assert aiocache.settings.DEFAULT_SERIALIZER_KWARGS == {"random_attr": "random_value"}
-
-    def test_set_default_serializer_class_fail(self):
-        with pytest.raises(ValueError):
-            aiocache.settings.set_default_serializer(
-                class_=aiocache.RedisCache, random_attr="random_value")
-
-    def test_set_default_plugins_str(self):
-        aiocache.settings.set_default_plugins(
-            [{"class": "aiocache.plugins.BasePlugin", "max_keys": 2}])
-
-        assert aiocache.settings.DEFAULT_PLUGINS == {
-            BasePlugin: {"max_keys": 2}}
-
-    def test_set_default_plugins_str_fail(self):
-        aiocache.settings.set_default_plugins(
-            [{"class": "aiocache.RedisCache", "random_attr": "random_value"}])
-
-        assert len(aiocache.settings.DEFAULT_PLUGINS) == 0
-
-    def test_set_default_plugins_class(self):
-        aiocache.settings.set_default_plugins(
-            [{"class": BasePlugin, "random_attr": "random_value"}])
-
-        assert aiocache.settings.DEFAULT_PLUGINS == {
-            BasePlugin: {"random_attr": "random_value"}}
-
-    def test_set_default_plugins_class_fail(self):
-        aiocache.settings.set_default_plugins(
-            [{"class": aiocache.RedisCache, "random_attr": "random_value"}])
-
-        assert len(aiocache.settings.DEFAULT_PLUGINS) == 0
+        assert settings._PLUGINS == {BasePlugin: {"max_keys": 2}}
 
     def test_get_defaults(self):
-        assert aiocache.settings.get_defaults() == {
-            "DEFAULT_CACHE": aiocache.SimpleMemoryCache,
-            "DEFAULT_CACHE_KWARGS": {},
-            "DEFAULT_SERIALIZER": DefaultSerializer,
-            "DEFAULT_SERIALIZER_KWARGS": {},
-            "DEFAULT_PLUGINS": {}
+        assert settings.get_defaults() == {
+            "CACHE": aiocache.SimpleMemoryCache,
+            "CACHE_KWARGS": {},
+            "SERIALIZER": DefaultSerializer,
+            "SERIALIZER_KWARGS": {},
+            "PLUGINS": {}
         }


### PR DESCRIPTION
before the approach was using globals and it was
messy because of adding proxies to set variables
and retrieving them. Now everything goes through
the Settings class which does all the work.

Also changed the contract of how to set defaults,
now the functions are called ``set_cache``,
``set_serializer`` and ``set_plugins`` and all
require the arg specifying the class.

Closes #169 