### PR TITLE
DefaultSerializer supports str types only.

### DIFF
--- a/aiocache/serializers.py
+++ b/aiocache/serializers.py
@@ -19,11 +19,8 @@ class DefaultSerializer:
     Dummy serializer that returns the same value passed both in serialize and
     deserialize methods.
 
-    There is an edge case to take into account with python types. Due to backends
-    working with bytes, although it may be possible to save an ``int`` type, when
-    retrieving it it will become an str. If you want to keep types, you will have
-    to use something like ``PickleSerializer`` or marshmallow custom serializer
-    class.
+    Supports only str values. If you want to store other python types, coerce them
+    to str or use ``PickleSerializer``/``JsonSerializer``.
     """
     encoding = 'utf-8'
 
@@ -31,6 +28,10 @@ class DefaultSerializer:
         super().__init__(*args, **kwargs)
 
     def dumps(self, value):
+        if not isinstance(value, str):
+            raise TypeError(
+                "DefaultSerializer only supports str types, for other types"
+                " check PickleSerializer or JsonSerializer")
         return value
 
     def loads(self, value):

--- a/docs/serializers.rst
+++ b/docs/serializers.rst
@@ -9,6 +9,12 @@ Serializers can be attached to backends in order to serialize/deserialize data s
     >>> from aiocache.serializers import PickleSerializer
     cache = SimpleMemoryCache(serializer=PickleSerializer())
 
+Currently the following are built in:
+
+- DefaultSerializer: ideal for storing str values.
+- PickleSerializer: ideal for storing any Python object.
+- JsonSerializer: ideal for storing in json format.
+
 In case the current serializers are not covering your needs, you can always define your custom serializer as shown in ``examples/serializer_class.py``.
 
 By default cache backends assume they are working with ``str`` types. If your custom implementation transform data to bytes, you will need to set the class attribute ``encoding`` to ``None``.

--- a/examples/plugins.py
+++ b/examples/plugins.py
@@ -24,10 +24,10 @@ cache = SimpleMemoryCache(
 
 
 async def run():
-    await cache.set("a", 1)
-    await cache.set("b", 2)
-    await cache.set("c", 3)
-    await cache.set("d", 4)
+    await cache.set("a", "1")
+    await cache.set("b", "2")
+    await cache.set("c", "3")
+    await cache.set("d", "4")
 
     possible_keys = ["a", "b", "c", "d", "e", "f"]
 

--- a/examples/serializer_class.py
+++ b/examples/serializer_class.py
@@ -19,7 +19,7 @@ class CompressionSerializer:
         return compressed
 
     def loads(self, value):
-        print("I've RETRIEVED:\n{}".format(value))
+        print("I've retrieved:\n{}".format(value))
         decompressed = zlib.decompress(value).decode()
         print("But I'm returning:\n{}".format(decompressed))
         return decompressed

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -60,3 +60,12 @@ def memcached_cache(event_loop):
 
     event_loop.run_until_complete(cache.delete(pytest.KEY))
     event_loop.run_until_complete(cache.delete(pytest.KEY_1))
+
+
+@pytest.fixture(params=[
+    'redis_cache',
+    'memory_cache',
+    'memcached_cache',
+])
+def cache(request):
+    return request.getfuncargvalue(request.param)

--- a/tests/acceptance/test_cache.py
+++ b/tests/acceptance/test_cache.py
@@ -1,65 +1,7 @@
 import pytest
 import asyncio
-import random
-import string
-
-from marshmallow import fields, Schema, post_load
 
 from aiocache import serializers, RedisCache
-
-
-@pytest.fixture(params=[
-    'redis_cache',
-    'memory_cache',
-    'memcached_cache',
-])
-def cache(request):
-    return request.getfuncargvalue(request.param)
-
-
-class MyType:
-    MY_CONSTANT = "CONSTANT"
-
-    def __init__(self, int_type=None, str_type=None, dict_type=None, list_type=None):
-        self.int_type = int_type or random.randint(1, 10)
-        self.str_type = str_type or random.choice(string.ascii_lowercase)
-        self.dict_type = dict_type or {}
-        self.list_type = list_type or []
-
-    def __eq__(self, obj):
-        return self.__dict__ == obj.__dict__
-
-
-class MyTypeSchema(Schema):
-    int_type = fields.Integer()
-    str_type = fields.String()
-    dict_type = fields.Dict()
-    list_type = fields.List(fields.Integer())
-
-    def dumps(self, *args, **kwargs):
-        return super().dumps(*args, **kwargs).data
-
-    def loads(self, *args, **kwargs):
-        return super().loads(*args, **kwargs).data
-
-    @post_load
-    def build_my_type(self, data):
-        return MyType(**data)
-
-    class Meta:
-        strict = True
-
-
-def dumps(x):
-    if x == "value":
-        return "v4lu3"
-    return 100
-
-
-def loads(x):
-    if x == "v4lu3":
-        return "value"
-    return 200
 
 
 class TestCache:
@@ -123,48 +65,6 @@ class TestCache:
         await asyncio.sleep(1.1)
 
         assert await cache.get(pytest.KEY) is None
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("obj, serializer", [
-        (MyType().str_type, serializers.DefaultSerializer),
-        (MyType(), serializers.PickleSerializer),
-        (MyType().__dict__, serializers.JsonSerializer),
-    ])
-    async def test_set_complex_type(self, cache, obj, serializer):
-        cache.serializer = serializer()
-        assert await cache.set(pytest.KEY, obj) is True
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("obj, serializer", [
-        (MyType().str_type, serializers.DefaultSerializer),
-        (MyType(), serializers.PickleSerializer),
-        (MyType().__dict__, serializers.JsonSerializer),
-    ])
-    async def test_get_complex_type(self, cache, obj, serializer):
-        cache.serializer = serializer()
-        await cache.set(pytest.KEY, obj)
-        assert await cache.get(pytest.KEY) == obj
-
-    @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="Incosistency with defaultserializer and backends")
-    async def test_get_complex_type_int(self, cache):
-        cache.serializer = serializers.DefaultSerializer()
-        await cache.set(pytest.KEY, 1)
-        assert await cache.get(pytest.KEY) == '1'
-
-    @pytest.mark.asyncio
-    async def test_get_set_alt_serializer_functions(self, cache):
-        await cache.set(pytest.KEY, "value", dumps_fn=dumps)
-        assert await cache.get(pytest.KEY) == "v4lu3"
-        assert await cache.get(pytest.KEY, loads_fn=loads) == "value"
-
-    @pytest.mark.asyncio
-    async def test_get_set_alt_serializer_class(self, cache):
-        my_serializer = MyTypeSchema()
-        my_obj = MyType()
-        cache.serializer = my_serializer
-        await cache.set(pytest.KEY, my_obj)
-        assert await cache.get(pytest.KEY) == my_serializer.loads(my_serializer.dumps(my_obj))
 
     @pytest.mark.asyncio
     async def test_add_missing(self, cache):

--- a/tests/acceptance/test_serializers.py
+++ b/tests/acceptance/test_serializers.py
@@ -1,0 +1,80 @@
+import pytest
+import random
+import string
+
+from marshmallow import fields, Schema, post_load
+
+from aiocache import serializers
+
+
+class MyType:
+    MY_CONSTANT = "CONSTANT"
+
+    def __init__(self, int_type=None, str_type=None, dict_type=None, list_type=None):
+        self.int_type = int_type or random.randint(1, 10)
+        self.str_type = str_type or random.choice(string.ascii_lowercase)
+        self.dict_type = dict_type or {}
+        self.list_type = list_type or []
+
+    def __eq__(self, obj):
+        return self.__dict__ == obj.__dict__
+
+
+class MyTypeSchema(Schema):
+    int_type = fields.Integer()
+    str_type = fields.String()
+    dict_type = fields.Dict()
+    list_type = fields.List(fields.Integer())
+
+    def dumps(self, *args, **kwargs):
+        return super().dumps(*args, **kwargs).data
+
+    def loads(self, *args, **kwargs):
+        return super().loads(*args, **kwargs).data
+
+    @post_load
+    def build_my_type(self, data):
+        return MyType(**data)
+
+    class Meta:
+        strict = True
+
+
+def dumps(x):
+    if x == "value":
+        return "v4lu3"
+    return 100
+
+
+def loads(x):
+    if x == "v4lu3":
+        return "value"
+    return 200
+
+
+class TestSerializer:
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("obj, serializer", [
+        (MyType().str_type, serializers.DefaultSerializer),
+        (MyType(), serializers.PickleSerializer),
+        (MyType().__dict__, serializers.JsonSerializer),
+    ])
+    async def test_get_complex_type(self, cache, obj, serializer):
+        cache.serializer = serializer()
+        assert await cache.set(pytest.KEY, obj) is True
+        assert await cache.get(pytest.KEY) == obj
+
+    @pytest.mark.asyncio
+    async def test_get_set_alt_serializer_functions(self, cache):
+        await cache.set(pytest.KEY, "value", dumps_fn=dumps)
+        assert await cache.get(pytest.KEY) == "v4lu3"
+        assert await cache.get(pytest.KEY, loads_fn=loads) == "value"
+
+    @pytest.mark.asyncio
+    async def test_get_set_alt_serializer_class(self, cache):
+        my_serializer = MyTypeSchema()
+        my_obj = MyType()
+        cache.serializer = my_serializer
+        await cache.set(pytest.KEY, my_obj)
+        assert await cache.get(pytest.KEY) == my_serializer.loads(my_serializer.dumps(my_obj))

--- a/tests/ut/test_serializers.py
+++ b/tests/ut/test_serializers.py
@@ -1,9 +1,26 @@
+import pytest
+
 from collections import namedtuple
 
-from aiocache.serializers import PickleSerializer, JsonSerializer
+from aiocache.serializers import DefaultSerializer, PickleSerializer, JsonSerializer
 
 
 Dummy = namedtuple("Dummy", "a, b")
+
+
+class TestDefaultSerializer:
+
+    @pytest.mark.parametrize("obj", [
+        1, True, ["1", 1], {"key": "value"}, Dummy(1, 2)])
+    def test_set_types(self, obj):
+        with pytest.raises(TypeError):
+            DefaultSerializer().dumps(obj)
+
+    def test_dumps(self):
+        assert DefaultSerializer().dumps("hi") == "hi"
+
+    def test_loads(self):
+        assert DefaultSerializer().loads("hi") == "hi"
 
 
 class TestPickleSerializer:


### PR DESCRIPTION
Behavior was not set explicitly although it was the original intention.
Due to incompatibilities between memcached, redis and memory, DefaultSerializer
was able to store different types depending on the backend. This is
unwanted incompatibility between backends and thus, has been restricted
to avoid surprises

Closes #124 and #37 