### PR TITLE
Feature #27/redis locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ ENV/
 
 dump.rdb
 _release_notes
+
+tags

--- a/aiocache/_lock.py
+++ b/aiocache/_lock.py
@@ -2,11 +2,19 @@ import asyncio
 import uuid
 
 
-class _Lock:
+class _DistributedLock:
     """
     Implementation of [Redlock](https://redis.io/topics/distlock)
     with a single instance because aiocache is focused on single
     instance cache.
+
+    Couple of considerations with the implementation:
+
+        - If the lease expires and there are clients waiting, all of them
+          will pass (blocking just happens for the first time).
+        - When a new client arrives, it will wait always at most lease
+          time. This means that the client could end up blocked longer
+          than needed in case the lease from the blocker expires.
     """
 
     _EVENTS = {}
@@ -27,18 +35,18 @@ class _Lock:
                 self.key,
                 self._value,
                 ttl=self.lease)
-            _Lock._EVENTS[self.key] = asyncio.Event()
+            _DistributedLock._EVENTS[self.key] = asyncio.Event()
         except ValueError:
             await self._wait_for_release()
 
     async def _wait_for_release(self):
         try:
             await asyncio.wait_for(
-                _Lock._EVENTS[self.key].wait(),
+                _DistributedLock._EVENTS[self.key].wait(),
                 self.lease)
         except asyncio.TimeoutError:
             pass
-        except KeyError:  # Lock was released when wait_for was rescheduled
+        except KeyError:  # lock was released when wait_for was rescheduled
             pass
 
     async def __aexit__(self, exc_type, exc_value, traceback):
@@ -47,5 +55,5 @@ class _Lock:
     async def _release(self):
         removed = await self.client._redlock_release(self.key, self._value)
         if removed:
-            _Lock._EVENTS.pop(self.key).set()
+            _DistributedLock._EVENTS.pop(self.key).set()
         return removed

--- a/aiocache/_lock.py
+++ b/aiocache/_lock.py
@@ -1,0 +1,51 @@
+import asyncio
+import uuid
+
+
+class _Lock:
+    """
+    Implementation of [Redlock](https://redis.io/topics/distlock)
+    with a single instance because aiocache is focused on single
+    instance cache.
+    """
+
+    _EVENTS = {}
+
+    def __init__(self, client, key, lease):
+        self.client = client
+        self.key = client._build_key(key + '-lock')
+        self.lease = lease
+        self._value = ""
+
+    async def __aenter__(self):
+        return await self._acquire()
+
+    async def _acquire(self):
+        self._value = str(uuid.uuid4())
+        try:
+            await self.client._add(
+                self.key,
+                self._value,
+                ttl=self.lease)
+            _Lock._EVENTS[self.key] = asyncio.Event()
+        except ValueError:
+            await self._wait_for_release()
+
+    async def _wait_for_release(self):
+        try:
+            await asyncio.wait_for(
+                _Lock._EVENTS[self.key].wait(),
+                self.lease)
+        except asyncio.TimeoutError:
+            pass
+        except KeyError:  # Lock was released when wait_for was rescheduled
+            pass
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return await self._release()
+
+    async def _release(self):
+        removed = await self.client._redlock_release(self.key, self._value)
+        if removed:
+            _Lock._EVENTS.pop(self.key).set()
+        return removed

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -61,7 +61,9 @@ class RedisBackend:
 
     @conn
     async def _set(self, key, value, ttl=None, _conn=None):
-        return await _conn.set(key, value, expire=ttl)
+        if ttl is None:
+            return await _conn.set(key, value)
+        return await _conn.setex(key, ttl, value)
 
     @conn
     async def _multi_set(self, pairs, ttl=None, _conn=None):

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -139,7 +139,7 @@ class RedisBackend:
             [value])
 
     async def _close(self, *args, **kwargs):
-        async with self._lock:
+        async with self._pool_lock:
             if self._pool is not None:
                 self._pool.close()
                 await self._pool.wait_closed()

--- a/aiocache/base.py
+++ b/aiocache/base.py
@@ -4,7 +4,7 @@ import functools
 import asyncio
 
 from aiocache import serializers
-from aiocache._lock import _Lock
+from aiocache._lock import _DistributedLock
 from aiocache.log import logger
 
 
@@ -225,7 +225,9 @@ class BaseCache:
 
         :param key: str
         :param value: obj
-        :param ttl: int the expiration time in seconds
+        :param ttl: int the expiration time in seconds. Due to memcached
+            restrictions if you want compatibility use int. In case you
+            need miliseconds, redis and memory support float ttls
         :param dumps_fn: callable alternative to use as dumps function
         :param namespace: str alternative namespace to use
         :param timeout: int or float in seconds specifying maximum timeout
@@ -254,7 +256,9 @@ class BaseCache:
         Stores multiple values in the given keys.
 
         :param pairs: list of two element iterables. First is key and second is value
-        :param ttl: int the expiration time of the keys in seconds
+        :param ttl: int the expiration time in seconds. Due to memcached
+            restrictions if you want compatibility use int. In case you
+            need miliseconds, redis and memory support float ttls
         :param dumps_fn: callable alternative to use as dumps function
         :param namespace: str alternative namespace to use
         :param timeout: int or float in seconds specifying maximum timeout
@@ -438,7 +442,7 @@ class BaseCache:
         return key
 
     def _lock(self, key, lease):
-        return _Lock(self, key, lease)
+        return _DistributedLock(self, key, lease)
 
     async def _redlock_release(self, key, value):
         raise NotImplementedError()

--- a/aiocache/base.py
+++ b/aiocache/base.py
@@ -4,6 +4,7 @@ import functools
 import asyncio
 
 from aiocache import serializers
+from aiocache._lock import _Lock
 from aiocache.log import logger
 
 
@@ -436,13 +437,19 @@ class BaseCache:
             return "{}{}".format(self.namespace, key)
         return key
 
+    def _lock(self, key, lease):
+        return _Lock(self, key, lease)
+
+    async def _redlock_release(self, key, value):
+        raise NotImplementedError()
+
     def get_connection(self):
         return _Conn(self)
 
-    async def acquire(self):
+    async def acquire_conn(self):
         return self
 
-    async def release(self, conn):
+    async def release_conn(self, conn):
         pass
 
 
@@ -453,11 +460,11 @@ class _Conn:
         self._conn = None
 
     async def __aenter__(self):
-        self._conn = await self._cache.acquire()
+        self._conn = await self._cache.acquire_conn()
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        await self._cache.release(self._conn)
+        await self._cache.release_conn(self._conn)
 
     def __getattr__(self, name):
         return self._cache.__getattribute__(name)

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -54,8 +54,9 @@ def cached(
                     args[1:] if noself else args) + str(kwargs))
 
             try:
-                if await cache_instance.exists(cache_key):
-                    return await cache_instance.get(cache_key)
+                value = await cache_instance.get(cache_key)
+                if value is not None:
+                    return value
 
             except Exception:
                 logger.exception("Unexpected error with %s", cache_instance)

--- a/tests/acceptance/test_base.py
+++ b/tests/acceptance/test_base.py
@@ -298,6 +298,7 @@ class TestRedisCache:
         assert redis_cache.get.call_count == 8
         assert redis_cache.set.call_count == 4
 
+    @pytest.mark.asyncio
     async def test_close(self, redis_cache):
         await redis_cache.set(pytest.KEY, "value")
         await redis_cache._close()

--- a/tests/acceptance/test_base.py
+++ b/tests/acceptance/test_base.py
@@ -54,7 +54,7 @@ class TestCache:
 
     @pytest.mark.asyncio
     async def test_multi_set_with_ttl(self, cache):
-        pairs = [(pytest.KEY, b"value"), [pytest.KEY_1, b"random_value"]]
+        pairs = [(pytest.KEY, "value"), [pytest.KEY_1, "random_value"]]
         assert await cache.multi_set(pairs, ttl=1) is True
         await asyncio.sleep(1.1)
 
@@ -145,6 +145,21 @@ class TestMemoryCache:
             SimpleMemoryCache(random_attr="wtf")
 
     @pytest.mark.asyncio
+    async def test_set_float_ttl(self, memory_cache):
+        await memory_cache.set(pytest.KEY, "value", ttl=0.1)
+        await asyncio.sleep(0.15)
+
+        assert await memory_cache.get(pytest.KEY) is None
+
+    @pytest.mark.asyncio
+    async def test_multi_set_float_ttl(self, memory_cache):
+        pairs = [(pytest.KEY, "value"), [pytest.KEY_1, "random_value"]]
+        assert await memory_cache.multi_set(pairs, ttl=0.1) is True
+        await asyncio.sleep(0.15)
+
+        assert await memory_cache.multi_get([pytest.KEY, pytest.KEY_1]) == [None, None]
+
+    @pytest.mark.asyncio
     async def test_raw(self, memory_cache):
         await memory_cache.raw("setdefault", "key", "value")
         assert await memory_cache.raw("get", "key") == "value"
@@ -152,7 +167,7 @@ class TestMemoryCache:
 
     @pytest.mark.asyncio
     async def test_clear_with_namespace_memory(self, memory_cache):
-        await memory_cache.set(pytest.KEY, b"value", namespace="test")
+        await memory_cache.set(pytest.KEY, "value", namespace="test")
         await memory_cache.clear(namespace="test")
 
         assert await memory_cache.exists(pytest.KEY, namespace="test") is False
@@ -164,6 +179,17 @@ class TestMemcachedCache:
     async def test_accept_explicit_args(self):
         with pytest.raises(TypeError):
             MemcachedCache(random_attr="wtf")
+
+    @pytest.mark.asyncio
+    async def test_set_float_ttl_fails(self, memcached_cache):
+        with pytest.raises(TypeError):
+            await memcached_cache.set(pytest.KEY, "value", ttl=0.1)
+
+    @pytest.mark.asyncio
+    async def test_multi_set_float_ttl(self, memcached_cache):
+        with pytest.raises(TypeError):
+            pairs = [(pytest.KEY, b"value"), [pytest.KEY_1, b"random_value"]]
+            assert await memcached_cache.multi_set(pairs, ttl=0.1) is True
 
     @pytest.mark.asyncio
     async def test_raw(self, memcached_cache):
@@ -188,6 +214,21 @@ class TestRedisCache:
     async def test_accept_explicit_args(self):
         with pytest.raises(TypeError):
             RedisCache(random_attr="wtf")
+
+    @pytest.mark.asyncio
+    async def test_float_ttl(self, redis_cache):
+        await redis_cache.set(pytest.KEY, "value", ttl=0.1)
+        await asyncio.sleep(0.15)
+
+        assert await redis_cache.get(pytest.KEY) is None
+
+    @pytest.mark.asyncio
+    async def test_multi_set_float_ttl(self, redis_cache):
+        pairs = [(pytest.KEY, "value"), [pytest.KEY_1, "random_value"]]
+        assert await redis_cache.multi_set(pairs, ttl=0.1) is True
+        await asyncio.sleep(0.15)
+
+        assert await redis_cache.multi_get([pytest.KEY, pytest.KEY_1]) == [None, None]
 
     @pytest.mark.asyncio
     async def test_raw(self, redis_cache):

--- a/tests/acceptance/test_lock.py
+++ b/tests/acceptance/test_lock.py
@@ -1,11 +1,11 @@
 import pytest
 
-from aiocache._lock import _Lock
+from aiocache._lock import _DistributedLock
 
 
 @pytest.fixture
 def lock(redis_cache):
-    return _Lock(redis_cache, pytest.KEY, 20)
+    return _DistributedLock(redis_cache, pytest.KEY, 20)
 
 
 class TestLock:

--- a/tests/acceptance/test_lock.py
+++ b/tests/acceptance/test_lock.py
@@ -1,0 +1,34 @@
+import pytest
+
+from aiocache._lock import _Lock
+
+
+@pytest.fixture
+def lock(redis_cache):
+    return _Lock(redis_cache, pytest.KEY, 20)
+
+
+class TestLock:
+
+    @pytest.mark.asyncio
+    async def test_acquire(self, redis_cache, lock):
+        await lock.__aenter__()
+        assert await redis_cache.get(pytest.KEY + '-lock') == lock._value
+        await redis_cache.delete(pytest.KEY + '-lock')
+
+    @pytest.mark.asyncio
+    async def test_release_does_nothing_when_no_lock(self, redis_cache, lock):
+        assert await lock.__aexit__("exc_type", "exc_value", "traceback") == 0
+
+    @pytest.mark.asyncio
+    async def test_release_does_nothing_when_wrong_token(self, redis_cache, lock):
+        await lock.__aenter__()
+        lock._value = "random"
+        assert await lock.__aexit__("exc_type", "exc_value", "traceback") == 0
+        await redis_cache.delete(pytest.KEY + '-lock')
+
+    @pytest.mark.asyncio
+    async def test_acquire_release(self, redis_cache, lock):
+        await lock.__aenter__()
+        assert await lock.__aexit__("exc_type", "exc_value", "traceback") == 1
+        assert await redis_cache.get(pytest.KEY + '-lock') is None

--- a/tests/ut/backends/test_memcached.py
+++ b/tests/ut/backends/test_memcached.py
@@ -67,6 +67,12 @@ class TestMemcachedBackend:
         memcached.client.set.assert_called_with(pytest.KEY, b"value", exptime=1)
 
     @pytest.mark.asyncio
+    async def test_set_float_ttl(self, memcached):
+        memcached.client.set.side_effect = aiomcache.exceptions.ValidationException("msg")
+        with pytest.raises(TypeError):
+            await memcached._set(pytest.KEY, "value", ttl=0.1)
+
+    @pytest.mark.asyncio
     async def test_multi_get(self, memcached):
         memcached.client.multi_get.return_value = [b"value", b"random"]
         assert await memcached._multi_get([pytest.KEY, pytest.KEY_1]) == ["value", "random"]
@@ -96,6 +102,12 @@ class TestMemcachedBackend:
         memcached.client.set.assert_any_call(pytest.KEY, b"value", exptime=1)
         memcached.client.set.assert_any_call(pytest.KEY_1, b"random", exptime=1)
         assert memcached.client.set.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_multi_set_float_ttl(self, memcached):
+        memcached.client.set.side_effect = aiomcache.exceptions.ValidationException("msg")
+        with pytest.raises(TypeError):
+            await memcached._multi_set([(pytest.KEY, "value"), (pytest.KEY_1, "random")], ttl=0.1)
 
     @pytest.mark.asyncio
     async def test_add(self, memcached):

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -154,10 +154,10 @@ class TestRedisBackend:
     async def test_set(self, redis):
         cache, pool = redis
         await cache._set(pytest.KEY, "value")
-        pool.conn.set.assert_called_with(pytest.KEY, "value", expire=None)
+        pool.conn.set.assert_called_with(pytest.KEY, "value")
 
         await cache._set(pytest.KEY, "value", ttl=1)
-        pool.conn.set.assert_called_with(pytest.KEY, "value", expire=1)
+        pool.conn.setex.assert_called_with(pytest.KEY, 1, "value")
 
     @pytest.mark.asyncio
     async def test_multi_get(self, redis):

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -264,6 +264,7 @@ class TestRedisBackend:
             "eval", cache.RELEASE_SCRIPT,
             [pytest.KEY], ["random"])
 
+    @pytest.mark.asyncio
     async def test_close_when_connected(self, redis):
         cache, pool = redis
         cache._pool = pool

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -46,8 +46,9 @@ class MockCache(BaseCache):
         self._expire = asynctest.CoroutineMock()
         self._clear = asynctest.CoroutineMock()
         self._raw = asynctest.CoroutineMock()
-        self.acquire = asynctest.CoroutineMock()
-        self.release = asynctest.CoroutineMock()
+        self._redlock_release = asynctest.CoroutineMock()
+        self.acquire_conn = asynctest.CoroutineMock()
+        self.release_conn = asynctest.CoroutineMock()
 
 
 @pytest.fixture

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -46,15 +46,10 @@ class MockCache(BaseCache):
         self._expire = asynctest.CoroutineMock()
         self._clear = asynctest.CoroutineMock()
         self._raw = asynctest.CoroutineMock()
-<<<<<<< HEAD
         self._redlock_release = asynctest.CoroutineMock()
         self.acquire_conn = asynctest.CoroutineMock()
         self.release_conn = asynctest.CoroutineMock()
         self._close = asynctest.CoroutineMock()
-=======
-        self.acquire = asynctest.CoroutineMock()
-        self.release = asynctest.CoroutineMock()
->>>>>>> master
 
 
 @pytest.fixture

--- a/tests/ut/test_base.py
+++ b/tests/ut/test_base.py
@@ -6,7 +6,7 @@ import asynctest
 from unittest.mock import patch, MagicMock, ANY
 
 from aiocache.base import API, _Conn
-from aiocache._lock import _Lock
+from aiocache._lock import _DistributedLock
 
 
 class TestAPI:
@@ -416,7 +416,7 @@ class TestCache:
         assert mock_cache.release_conn.call_count == 1
 
     def test_lock(self, mock_cache):
-        assert isinstance(mock_cache._lock(pytest.KEY, 20), _Lock)
+        assert isinstance(mock_cache._lock(pytest.KEY, 20), _DistributedLock)
 
 
 @pytest.fixture

--- a/tests/ut/test_base.py
+++ b/tests/ut/test_base.py
@@ -6,6 +6,7 @@ import asynctest
 from unittest.mock import patch, MagicMock, ANY
 
 from aiocache.base import API, _Conn
+from aiocache._lock import _Lock
 
 
 class TestAPI:
@@ -197,12 +198,17 @@ class TestBaseCache:
             await base_cache._raw("get", pytest.KEY)
 
     @pytest.mark.asyncio
-    async def test_acquire(self, base_cache):
-        assert await base_cache.acquire() == base_cache
+    async def test_redlock_release(self, base_cache):
+        with pytest.raises(NotImplementedError):
+            await base_cache._redlock_release(pytest.KEY, 20)
 
     @pytest.mark.asyncio
-    async def test_release(self, base_cache):
-        await base_cache.release("mock") is None
+    async def test_acquire_conn(self, base_cache):
+        assert await base_cache.acquire_conn() == base_cache
+
+    @pytest.mark.asyncio
+    async def test_release_conn(self, base_cache):
+        await base_cache.release_conn("mock") is None
 
     @pytest.fixture
     def set_test_namespace(self, base_cache):
@@ -406,8 +412,11 @@ class TestCache:
     async def test_get_connection(self, mock_cache):
         async with mock_cache.get_connection():
             pass
-        assert mock_cache.acquire.call_count == 1
-        assert mock_cache.release.call_count == 1
+        assert mock_cache.acquire_conn.call_count == 1
+        assert mock_cache.release_conn.call_count == 1
+
+    def test_lock(self, mock_cache):
+        assert isinstance(mock_cache._lock(pytest.KEY, 20), _Lock)
 
 
 @pytest.fixture
@@ -428,8 +437,8 @@ class TestConn:
     @pytest.mark.asyncio
     async def test_conn_context_manager(self, conn):
         async with conn:
-            assert conn._cache.acquire.call_count == 1
-        conn._cache.release.assert_called_with(conn._cache.acquire.return_value)
+            assert conn._cache.acquire_conn.call_count == 1
+        conn._cache.release_conn.assert_called_with(conn._cache.acquire_conn.return_value)
 
     @pytest.mark.asyncio
     async def test_inject_conn(self, conn):

--- a/tests/ut/test_lock.py
+++ b/tests/ut/test_lock.py
@@ -1,0 +1,81 @@
+import asyncio
+import pytest
+import asynctest
+
+from aiocache._lock import _Lock
+
+
+@pytest.fixture
+def lock(mock_cache):
+    _Lock._EVENTS = {}
+    yield _Lock(mock_cache, pytest.KEY, 20)
+
+
+class TestLock:
+
+    @pytest.mark.asyncio
+    async def test_acquire(self, mock_cache, lock):
+        await lock._acquire()
+        mock_cache._add.assert_called_with(
+            pytest.KEY + '-lock', lock._value, ttl=20)
+        assert lock._EVENTS[pytest.KEY + '-lock'].is_set() is False
+
+    @pytest.mark.asyncio
+    async def test_release(self, mock_cache, lock):
+        await lock._acquire()
+        await lock._release()
+        mock_cache._redlock_release.assert_called_with(
+            pytest.KEY + '-lock',
+            lock._value)
+        assert pytest.KEY + '-lock' not in lock._EVENTS
+
+    @pytest.mark.asyncio
+    async def test_second_release(self, mock_cache, lock):
+        await lock._acquire()
+        mock_cache._redlock_release.side_effect = [True, False]
+        assert pytest.KEY + '-lock' in lock._EVENTS
+        assert await lock._release() is True
+        assert pytest.KEY + '-lock' not in lock._EVENTS
+        assert await lock._release() is False
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, mock_cache, lock):
+        async with lock:
+            pass
+        mock_cache._add.assert_called_with(
+            pytest.KEY + '-lock', lock._value, ttl=20)
+        mock_cache._redlock_release.assert_called_with(
+            pytest.KEY + '-lock',
+            lock._value)
+
+    @pytest.mark.asyncio
+    async def test_acquire_block_timeouts(self, mock_cache, lock):
+        await lock._acquire()
+        with asynctest.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+            mock_cache._add.side_effect = ValueError
+            assert await lock._acquire() is None
+
+    @pytest.mark.asyncio
+    async def test_wait_for_release_no_acquire(self, mock_cache, lock):
+        mock_cache._add.side_effect = ValueError
+        assert await lock._acquire() is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_locks_lock(self, mock_cache, lock, event_loop):
+        lock_1 = _Lock(mock_cache, pytest.KEY, 20)
+        lock_2 = _Lock(mock_cache, pytest.KEY, 20)
+        mock_cache._add.side_effect = [True, ValueError(), ValueError()]
+        await lock._acquire()
+        event = lock._EVENTS[pytest.KEY + '-lock']
+
+        assert pytest.KEY + '-lock' in lock._EVENTS
+        assert pytest.KEY + '-lock' in lock_1._EVENTS
+        assert pytest.KEY + '-lock' in lock_2._EVENTS
+        assert not event.is_set()
+
+        await asyncio.gather(lock_1._acquire(), lock._release(), lock_2._acquire())
+
+        assert pytest.KEY + '-lock' not in lock._EVENTS
+        assert pytest.KEY + '-lock' not in lock_1._EVENTS
+        assert pytest.KEY + '-lock' not in lock_2._EVENTS
+        assert event.is_set()

--- a/tests/ut/test_lock.py
+++ b/tests/ut/test_lock.py
@@ -2,13 +2,13 @@ import asyncio
 import pytest
 import asynctest
 
-from aiocache._lock import _Lock
+from aiocache._lock import _DistributedLock
 
 
 @pytest.fixture
 def lock(mock_cache):
-    _Lock._EVENTS = {}
-    yield _Lock(mock_cache, pytest.KEY, 20)
+    _DistributedLock._EVENTS = {}
+    yield _DistributedLock(mock_cache, pytest.KEY, 20)
 
 
 class TestLock:
@@ -62,8 +62,8 @@ class TestLock:
 
     @pytest.mark.asyncio
     async def test_multiple_locks_lock(self, mock_cache, lock, event_loop):
-        lock_1 = _Lock(mock_cache, pytest.KEY, 20)
-        lock_2 = _Lock(mock_cache, pytest.KEY, 20)
+        lock_1 = _DistributedLock(mock_cache, pytest.KEY, 20)
+        lock_2 = _DistributedLock(mock_cache, pytest.KEY, 20)
         mock_cache._add.side_effect = [True, ValueError(), ValueError()]
         await lock._acquire()
         event = lock._EVENTS[pytest.KEY + '-lock']


### PR DESCRIPTION
Adds support for Redis distributed lock to avoid cache stampede effects. For now its not applied anywhere and functions/class is private.

Once implementation for memcached and memory is done, I'll add support for cached decorator at first and make it public as a on demand feature after. The implementation for memcached and memory won't be hard now that the base is set with Redis.

Some things to still add in this MR:

- ~Lease time should support miliseconds (now its just seconds). I think this will raise a problem for memcached since it doesn't support it?~
- There is a worst case scenario for operations that take the whole lease time N. If a call arrives 0.1 ms before the lease expires, the call will be blocked N while it would only need 0.1 to continue. Gonna leave it like that (documented in the class).
- If the lease expires, ALL calls will try to retrieve the value from the resource that its being protected. I've decided to do it this way to avoid block the calls too much waiting for leases that could always be expiring. Gonna leave it like that (documented in the class).

@gjcarneiro what do you think, is there anything you are missing? You can see an example of it working in https://github.com/argaen/aiocache/compare/feature_%2327/redis_locking?expand=1#diff-61192af138ef98c9b82cba13168e6e12R205 (the `asyncio.sleep` there represents the expensive operation)