### PR TITLE
Change close to clear for redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,12 @@ pylint:
 	pylint --disable=C0111 aiocache
 
 ut:
-	pytest -sv tests/ut
+	pytest --cov-report term-missing --cov=aiocache -sv tests/ut
 
 _acceptance:
 	pytest -sv tests/acceptance
 
 acceptance: dockerup _acceptance dockerdown
-
-cov:
-	pytest --cov-report term-missing --cov=aiocache -sv tests/ut
 
 doc:
 	make -C docs/ html

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -81,9 +81,6 @@ class SimpleMemoryBackend:
     async def _raw(self, command, *args, encoding="utf-8", _conn=None, **kwargs):
         return getattr(SimpleMemoryBackend._cache, command)(*args, **kwargs)
 
-    async def _close(self, *args, _con=None, **kwargs):
-        pass
-
     @classmethod
     def __delete(cls, key):
         if cls._cache.pop(key, None):

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -122,10 +122,8 @@ class RedisBackend:
         return await getattr(_conn, command)(*args, **kwargs)
 
     async def _close(self, *args, **kwargs):
-        async with self._lock:
-            if self._pool is not None:
-                self._pool.close()
-                await self._pool.wait_closed()
+        if self._pool is not None:
+            await self._pool.clear()
 
     async def _connect(self):
         async with self._lock:

--- a/aiocache/base.py
+++ b/aiocache/base.py
@@ -432,8 +432,9 @@ class BaseCache:
     @API.timeout
     async def close(self, *args, _conn=None, **kwargs):
         """
-        Perform any resource clean up necessary when the cache is no longer
-        needed (generally when the controlling program exits).
+        Perform any resource clean up necessary to exit the program safely.
+        After closing, cmd execution is still possible but you will have to
+        close again before exiting.
 
         :raises: :class:`asyncio.TimeoutError` if it lasts more than self.timeout
         """
@@ -443,7 +444,7 @@ class BaseCache:
         return ret
 
     async def _close(self, *args, **kwargs):
-        raise NotImplementedError()
+        pass
 
     def _build_key(self, key, namespace=None):
         if namespace is not None:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -36,10 +36,6 @@ def redis_cache(event_loop):
 
     event_loop.run_until_complete(cache.delete(pytest.KEY))
     event_loop.run_until_complete(cache.delete(pytest.KEY_1))
-
-    for _, pool in RedisBackend.pools.items():
-        pool.close()
-        event_loop.run_until_complete(pool.wait_closed())
     event_loop.run_until_complete(cache.close())
 
 

--- a/tests/ut/backends/test_memcached.py
+++ b/tests/ut/backends/test_memcached.py
@@ -187,10 +187,9 @@ class TestMemcachedBackend:
         memcached.client.set.assert_called_with(pytest.KEY, "asd")
 
     @pytest.mark.asyncio
-    async def test_close(self):
-        memcached = MemcachedBackend()
+    async def test_close(self, memcached):
         await memcached._close()
-        assert memcached.client._pool._pool.empty()
+        assert memcached.client.close.call_count == 1
 
 
 class TestMemcachedCache:

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -46,7 +46,6 @@ class MockCache(BaseCache):
         self._expire = asynctest.CoroutineMock()
         self._clear = asynctest.CoroutineMock()
         self._raw = asynctest.CoroutineMock()
-        self._close = asynctest.CoroutineMock()
         self.acquire = asynctest.CoroutineMock()
         self.release = asynctest.CoroutineMock()
 

--- a/tests/ut/test_base.py
+++ b/tests/ut/test_base.py
@@ -198,8 +198,7 @@ class TestBaseCache:
 
     @pytest.mark.asyncio
     async def test_close(self, base_cache):
-        with pytest.raises(NotImplementedError):
-            await base_cache._close()
+        assert await base_cache._close() is None
 
     @pytest.mark.asyncio
     async def test_acquire(self, base_cache):
@@ -413,10 +412,6 @@ class TestCache:
             pass
         assert mock_cache.acquire.call_count == 1
         assert mock_cache.release.call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_close(self, mock_cache):
-        await mock_cache.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
clear will free connections but will allow the user to
still use the cached if needed (same behavior for
aiomcache and ofc memory).

Also fix couple of ut that were depending on
Redis instance running