### PR TITLE
Removed connection reusage for decorators

### DIFF
--- a/tests/ut/test_base.py
+++ b/tests/ut/test_base.py
@@ -413,6 +413,11 @@ class TestCache:
             await mock_cache.raw("clear")
 
     @pytest.mark.asyncio
+    async def test_close(self, mock_cache):
+        await mock_cache.close()
+        assert mock_cache._close.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_get_connection(self, mock_cache):
         async with mock_cache.get_connection():
             pass


### PR DESCRIPTION
when decorated function is costly connections where being kept
while being iddle. This is a bad scenario and this reverts back
to using a connection from the cache pool for every cache
operation