### PR TITLE
Memory now uses new NullSerializer

### DIFF
--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -2,6 +2,7 @@ import asyncio
 import aiomcache
 
 from aiocache.base import BaseCache
+from aiocache.serializers import JsonSerializer
 
 
 class MemcachedBackend:
@@ -114,7 +115,7 @@ class MemcachedBackend:
 class MemcachedCache(MemcachedBackend, BaseCache):
     """
     Memcached cache implementation with the following components as defaults:
-        - serializer: :class:`aiocache.serializers.StringSerializer`
+        - serializer: :class:`aiocache.serializers.JsonSerializer`
         - plugins: []
 
     Config options are:
@@ -129,8 +130,9 @@ class MemcachedCache(MemcachedBackend, BaseCache):
     :param port: int with the port to connect to. Default is 11211.
     :param pool_size: int size for memcached connections pool. Default is 2.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, serializer=None, **kwargs):
         super().__init__(**kwargs)
+        self.serializer = serializer or JsonSerializer()
 
     def _build_key(self, key, namespace=None):
         ns_key = super()._build_key(key, namespace=namespace).replace(' ', '_')

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from aiocache.base import BaseCache
+from aiocache.serializers import NullSerializer
 
 
 class SimpleMemoryBackend:
@@ -101,7 +102,7 @@ class SimpleMemoryBackend:
 class SimpleMemoryCache(SimpleMemoryBackend, BaseCache):
     """
     Memory cache implementation with the following components as defaults:
-        - serializer: :class:`aiocache.serializers.StringSerializer`
+        - serializer: :class:`aiocache.serializers.JsonSerializer`
         - plugins: None
 
     Config options are:
@@ -113,5 +114,6 @@ class SimpleMemoryCache(SimpleMemoryBackend, BaseCache):
     :param timeout: int or float in seconds specifying maximum timeout for the operations to last.
         By default its 5.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, serializer=None, **kwargs):
         super().__init__(**kwargs)
+        self.serializer = serializer or NullSerializer()

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -5,6 +5,7 @@ import functools
 import aioredis
 
 from aiocache.base import BaseCache
+from aiocache.serializers import JsonSerializer
 
 
 def conn(func):
@@ -164,7 +165,7 @@ class RedisBackend:
 class RedisCache(RedisBackend, BaseCache):
     """
     Redis cache implementation with the following components as defaults:
-        - serializer: :class:`aiocache.serializers.StringSerializer`
+        - serializer: :class:`aiocache.serializers.JsonSerializer`
         - plugins: []
 
     Config options are:
@@ -182,8 +183,9 @@ class RedisCache(RedisBackend, BaseCache):
     :param pool_min_size: int minimum pool size for the redis connections pool. Default is 1
     :param pool_max_size: int maximum pool size for the redis connections pool. Default is 10
     """
-    def __init__(self, **kwargs):
+    def __init__(self, serializer=None, **kwargs):
         super().__init__(**kwargs)
+        self.serializer = serializer or JsonSerializer()
 
     def _build_key(self, key, namespace=None):
         if namespace is not None:

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -3,7 +3,6 @@ import functools
 
 from aiocache.log import logger
 from aiocache import SimpleMemoryCache, caches
-from aiocache.serializers import JsonSerializer
 
 
 class cached:
@@ -26,7 +25,7 @@ class cached:
     :param cache: cache class to use when calling the ``set``/``get`` operations.
         Default is ``aiocache.SimpleMemoryCache``.
     :param serializer: serializer instance to use when calling the ``dumps``/``loads``.
-        Default is JsonSerializer.
+        If its None, default one from the cache backend is used.
     :param plugins: list plugins to use when calling the cmd hooks
         Default is pulled from the cache class being used.
     :param alias: str specifying the alias to load the config from. If alias is passed, other config
@@ -38,7 +37,7 @@ class cached:
 
     def __init__(
             self, ttl=None, key=None, key_from_attr=None, key_builder=None, cache=SimpleMemoryCache,
-            serializer=JsonSerializer, plugins=None, alias=None, noself=False, **kwargs):
+            serializer=None, plugins=None, alias=None, noself=False, **kwargs):
         self.ttl = ttl
         self.key = key
         if key_from_attr is not None:
@@ -202,7 +201,7 @@ class multi_cached:
     :param cache: cache class to use when calling the ``multi_set``/``multi_get`` operations.
         Default is ``aiocache.SimpleMemoryCache``.
     :param serializer: serializer instance to use when calling the ``dumps``/``loads``.
-        Default is JsonSerializer.
+        If its None, default one from the cache backend is used.
     :param plugins: plugins to use when calling the cmd hooks
         Default is pulled from the cache class being used.
     :param alias: str specifying the alias to load the config from. If alias is passed, other config
@@ -211,7 +210,7 @@ class multi_cached:
 
     def __init__(
             self, keys_from_attr, key_builder=None, ttl=0, cache=SimpleMemoryCache,
-            serializer=JsonSerializer, plugins=None, alias=None, **kwargs):
+            serializer=None, plugins=None, alias=None, **kwargs):
         self.keys_from_attr = keys_from_attr
         self.key_builder = key_builder or (lambda key, *args, **kwargs: key)
         self.ttl = ttl

--- a/aiocache/serializers.py
+++ b/aiocache/serializers.py
@@ -10,6 +10,38 @@ except ImportError:
 import pickle
 
 
+class NullSerializer:
+    """
+    This serializer does nothing. Its only recommended to be used by
+    :class:`aiocache.SimpleMemoryCache` because for other backends it will
+    produce incompatible data unless you work only with str types.
+
+    DISCLAIMER: Be careful with mutable types and memory storage. The following
+    behavior is considered normal (same as ``functools.lru_cache``)::
+
+        cache = SimpleMemoryCache()
+        my_list = [1]
+        await cache.set("key", my_list)
+        my_list.append(2)
+        await cache.get("key")  # Will return [1, 2]
+    """
+    encoding = 'utf-8'
+
+    @classmethod
+    def dumps(cls, value):
+        """
+        Returns the same value
+        """
+        return value
+
+    @classmethod
+    def loads(cls, value):
+        """
+        Returns the same value
+        """
+        return value
+
+
 class StringSerializer:
     """
     Converts all input values to str. All return values are also str. Be

--- a/examples/serializer_function.py
+++ b/examples/serializer_function.py
@@ -38,7 +38,7 @@ async def serializer_function():
 
     assert obj.x == 1
     assert obj.y == 2
-    assert json.loads((await cache.get("key"))) == json.loads(('{"y": 2.0, "x": 1.0}'))
+    assert await cache.get("key") == json.loads(('{"y": 2.0, "x": 1.0}'))
     assert json.loads(await cache.raw("get", "main:key")) == {"y": 2.0, "x": 1.0}
 
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -18,7 +18,7 @@ def reset_caches():
         'default': {
             'cache': "aiocache.SimpleMemoryCache",
             'serializer': {
-                'class': "aiocache.serializers.StringSerializer"
+                'class': "aiocache.serializers.NullSerializer"
             }
         }
     })

--- a/tests/acceptance/test_base.py
+++ b/tests/acceptance/test_base.py
@@ -1,7 +1,7 @@
 import pytest
 import asyncio
 
-from aiocache import serializers, RedisCache, SimpleMemoryCache, MemcachedCache
+from aiocache import RedisCache, SimpleMemoryCache, MemcachedCache
 from aiocache.base import _Conn
 
 
@@ -14,7 +14,6 @@ class TestCache:
     @pytest.mark.asyncio
     async def test_setup(self, cache):
         assert cache.namespace == "test"
-        assert isinstance(cache.serializer, serializers.StringSerializer)
 
     @pytest.mark.asyncio
     async def test_get_missing(self, cache):
@@ -93,7 +92,7 @@ class TestCache:
 
     @pytest.mark.asyncio
     async def test_increment_existing(self, cache):
-        await cache.set(pytest.KEY, "2")
+        await cache.set(pytest.KEY, 2)
         assert await cache.increment(pytest.KEY, delta=2) == 4
         assert await cache.increment(pytest.KEY, delta=1) == 5
         assert await cache.increment(pytest.KEY, delta=-3) == 2

--- a/tests/acceptance/test_lock.py
+++ b/tests/acceptance/test_lock.py
@@ -2,6 +2,7 @@ import asyncio
 import pytest
 
 from aiocache._lock import _RedLock
+from aiocache.serializers import StringSerializer
 
 
 @pytest.fixture
@@ -14,6 +15,7 @@ class TestRedLock:
     @pytest.mark.asyncio
     async def test_acquire(self, cache, lock):
         await lock.__aenter__()
+        cache.serializer = StringSerializer()
         assert await cache.get(pytest.KEY + '-lock') == lock._value
 
     @pytest.mark.asyncio

--- a/tests/acceptance/test_serializers.py
+++ b/tests/acceptance/test_serializers.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from marshmallow import fields, Schema, post_load
 
-from aiocache.serializers import StringSerializer, PickleSerializer, JsonSerializer
+from aiocache.serializers import NullSerializer, StringSerializer, PickleSerializer, JsonSerializer
 
 
 class MyType:
@@ -54,6 +54,30 @@ def loads(x):
 
 
 TYPES = [1, 2.0, "hi", True, ["1", 1], {"key": "value"}, MyType()]
+
+
+class TestNullSerializer:
+
+    @pytest.mark.parametrize("obj", TYPES)
+    @pytest.mark.asyncio
+    async def test_set_get_types(self, memory_cache, obj):
+        memory_cache.serializer = NullSerializer()
+        assert await memory_cache.set(pytest.KEY, obj) is True
+        assert await memory_cache.get(pytest.KEY) is obj
+
+    @pytest.mark.parametrize("obj", TYPES)
+    @pytest.mark.asyncio
+    async def test_add_get_types(self, memory_cache, obj):
+        memory_cache.serializer = NullSerializer()
+        assert await memory_cache.add(pytest.KEY, obj) is True
+        assert await memory_cache.get(pytest.KEY) is obj
+
+    @pytest.mark.parametrize("obj", TYPES)
+    @pytest.mark.asyncio
+    async def test_multi_set_multi_get_types(self, memory_cache, obj):
+        memory_cache.serializer = NullSerializer()
+        assert await memory_cache.multi_set([(pytest.KEY, obj)]) is True
+        assert (await memory_cache.multi_get([pytest.KEY]))[0] is obj
 
 
 class TestStringSerializer:
@@ -132,6 +156,7 @@ class TestAltSerializers:
 
     @pytest.mark.asyncio
     async def test_get_set_alt_serializer_functions(self, cache):
+        cache.serializer = StringSerializer
         await cache.set(pytest.KEY, "value", dumps_fn=dumps)
         assert await cache.get(pytest.KEY) == "v4lu3"
         assert await cache.get(pytest.KEY, loads_fn=loads) == "value"

--- a/tests/ut/backends/test_memcached.py
+++ b/tests/ut/backends/test_memcached.py
@@ -5,6 +5,7 @@ from asynctest import MagicMock, patch, ANY
 
 from aiocache import MemcachedCache
 from aiocache.base import BaseCache
+from aiocache.serializers import JsonSerializer
 from aiocache.backends.memcached import MemcachedBackend
 
 
@@ -226,6 +227,9 @@ class TestMemcachedCache:
 
     def test_inheritance(self):
         assert isinstance(MemcachedCache(), BaseCache)
+
+    def test_default_serializer(self):
+        assert isinstance(MemcachedCache().serializer, JsonSerializer)
 
     @pytest.mark.parametrize("namespace, expected", (
         [None, "test" + pytest.KEY],

--- a/tests/ut/backends/test_memory.py
+++ b/tests/ut/backends/test_memory.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from aiocache import SimpleMemoryCache
 from aiocache.base import BaseCache
+from aiocache.serializers import NullSerializer
 from aiocache.backends.memory import SimpleMemoryBackend
 
 
@@ -176,3 +177,6 @@ class TestSimpleMemoryCache:
 
     def test_inheritance(self):
         assert isinstance(SimpleMemoryCache(), BaseCache)
+
+    def test_default_serializer(self):
+        assert isinstance(SimpleMemoryCache().serializer, NullSerializer)

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -5,6 +5,7 @@ from asynctest import CoroutineMock, MagicMock, patch, ANY
 
 from aiocache import RedisCache
 from aiocache.base import BaseCache
+from aiocache.serializers import JsonSerializer
 from aiocache.backends.redis import RedisBackend, conn
 
 
@@ -331,6 +332,9 @@ class TestRedisCache:
 
     def test_inheritance(self):
         assert isinstance(RedisCache(), BaseCache)
+
+    def test_default_serializer(self):
+        assert isinstance(RedisCache().serializer, JsonSerializer)
 
     @pytest.mark.parametrize("namespace, expected", (
         [None, "test:" + pytest.KEY],

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -4,7 +4,7 @@ import asynctest
 from aiocache.base import BaseCache, API
 from aiocache import caches, RedisCache, MemcachedCache
 from aiocache.plugins import BasePlugin
-from aiocache.serializers import StringSerializer
+from aiocache.serializers import NullSerializer
 
 
 def pytest_namespace():
@@ -20,7 +20,7 @@ def reset_caches():
         'default': {
             'cache': "aiocache.SimpleMemoryCache",
             'serializer': {
-                'class': "aiocache.serializers.StringSerializer"
+                'class': "aiocache.serializers.NullSerializer"
             }
         }
     })
@@ -61,7 +61,7 @@ def mock_cache(mocker):
         mocker.spy(cache, cmd.__name__)
     mocker.spy(cache, "close")
     mocker.spy(cache, "_redlock")
-    cache.serializer = asynctest.Mock(spec=StringSerializer)
+    cache.serializer = asynctest.Mock(spec=NullSerializer)
     cache.plugins = [asynctest.Mock(spec=BasePlugin)]
     return cache
 

--- a/tests/ut/test_decorators.py
+++ b/tests/ut/test_decorators.py
@@ -10,7 +10,6 @@ from asynctest import MagicMock, CoroutineMock, ANY
 from aiocache.base import BaseCache
 from aiocache import cached, cached_stampede, multi_cached, SimpleMemoryCache
 from aiocache.decorators import _get_args_dict
-from aiocache.serializers import JsonSerializer
 
 
 async def stub(*args, value=None, seconds=0, **kwargs):
@@ -48,7 +47,7 @@ class TestCached:
         assert c.key_from_attr == "key_attr"
         assert c.cache is None
         assert c._cache == SimpleMemoryCache
-        assert c._serializer == JsonSerializer
+        assert c._serializer is None
         assert c._kwargs == {'namespace': 'test'}
 
     def test_fails_at_instantiation(self):
@@ -217,7 +216,7 @@ class TestCachedStampede:
         assert c.key_from_attr == "key_attr"
         assert c.cache is None
         assert c._cache == SimpleMemoryCache
-        assert c._serializer == JsonSerializer
+        assert c._serializer is None
         assert c.lease == 3
         assert c._kwargs == {'namespace': 'test'}
 
@@ -302,7 +301,7 @@ class TestMultiCached:
         assert mc.keys_from_attr == "keys"
         assert mc.cache is None
         assert mc._cache == SimpleMemoryCache
-        assert mc._serializer == JsonSerializer
+        assert mc._serializer is None
         assert mc._kwargs == {'namespace': 'test'}
 
     def test_fails_at_instantiation(self):

--- a/tests/ut/test_factory.py
+++ b/tests/ut/test_factory.py
@@ -190,7 +190,7 @@ class TestCacheHandler:
             'default': {
                 'cache': "aiocache.SimpleMemoryCache",
                 'serializer': {
-                    'class': "aiocache.serializers.StringSerializer"
+                    'class': "aiocache.serializers.NullSerializer"
                 }
             }
         }
@@ -199,7 +199,7 @@ class TestCacheHandler:
         assert caches.get_alias_config("default") == {
             'cache': "aiocache.SimpleMemoryCache",
             'serializer': {
-                'class': "aiocache.serializers.StringSerializer"
+                'class': "aiocache.serializers.NullSerializer"
             }
         }
 

--- a/tests/ut/test_serializers.py
+++ b/tests/ut/test_serializers.py
@@ -6,10 +6,20 @@ except ImportError:
 
 from collections import namedtuple
 
-from aiocache.serializers import StringSerializer, PickleSerializer, JsonSerializer
+from aiocache.serializers import NullSerializer, StringSerializer, PickleSerializer, JsonSerializer
 
 
 Dummy = namedtuple("Dummy", "a, b")
+
+
+class TestNullSerializer:
+    @pytest.mark.parametrize("obj", [
+        1, 2.0, "hi", True, ["1", 1], {"key": "value"}, Dummy(1, 2)])
+    def test_set_types(self, obj):
+        assert NullSerializer().dumps(obj) is obj
+
+    def test_loads(self):
+        assert NullSerializer().loads("hi") is "hi"
 
 
 class TestStringSerializer:

--- a/tests/ut/test_settings.py
+++ b/tests/ut/test_settings.py
@@ -13,7 +13,7 @@ class TestSettings:
             'default': {
                 'cache': "aiocache.SimpleMemoryCache",
                 'serializer': {
-                    'class': "aiocache.serializers.StringSerializer"
+                    'class': "aiocache.serializers.NullSerializer"
                 }
             }
         }
@@ -22,7 +22,7 @@ class TestSettings:
         assert settings.get_alias("default") == {
             'cache': "aiocache.SimpleMemoryCache",
             'serializer': {
-                'class': "aiocache.serializers.StringSerializer"
+                'class': "aiocache.serializers.NullSerializer"
             }
         }
 


### PR DESCRIPTION
Memory is a special case and doesn't need a serializer
because anything can be stored in memory. Created a new
NullSerializer that does nothing which is the default
that SimpleMemoryCache will use now.

Closes #269 