### PR TITLE
Added ttl parameter in cache class

### DIFF
--- a/aiocache/base.py
+++ b/aiocache/base.py
@@ -9,7 +9,7 @@ from aiocache import serializers
 
 logger = logging.getLogger(__file__)
 
-sentinel = object()
+SENTINEL = object()
 
 
 class API:
@@ -93,17 +93,17 @@ class BaseCache:
         list.
     :param namespace: string to use as default prefix for the key used in all operations of
         the backend. Default is None
-    :param ttl: int the expiration time in seconds to use as a default in all operations of
-        the backend. It can be overriden in the specific calls.
     :param key_builder: alternative callable to build the key. Receives the key and the namespace as
         params and should return something that can be used as key by the underlying backend.
     :param timeout: int or float in seconds specifying maximum timeout for the operations to last.
         By default its 5. Use 0 or None if you want to disable it.
+    :param ttl: int the expiration time in seconds to use as a default in all operations of
+        the backend. It can be overriden in the specific calls.
     """
 
     def __init__(
             self, serializer=None, plugins=None,
-            namespace=None, ttl=None, key_builder=None, timeout=5):
+            namespace=None, key_builder=None, timeout=5, ttl=None):
         self.timeout = timeout
         self.namespace = namespace
         self.ttl = ttl
@@ -135,7 +135,7 @@ class BaseCache:
     @API.aiocache_enabled(fake_return=True)
     @API.timeout
     @API.plugins
-    async def add(self, key, value, ttl=sentinel, dumps_fn=None, namespace=None, _conn=None):
+    async def add(self, key, value, ttl=SENTINEL, dumps_fn=None, namespace=None, _conn=None):
         """
         Stores the value in the given key with ttl if specified. Raises an error if the
         key already exists.
@@ -233,7 +233,7 @@ class BaseCache:
     @API.timeout
     @API.plugins
     async def set(
-            self, key, value, ttl=sentinel, dumps_fn=None, namespace=None, _cas_token=None,
+            self, key, value, ttl=SENTINEL, dumps_fn=None, namespace=None, _cas_token=None,
             _conn=None):
         """
         Stores the value in the given key with ttl if specified
@@ -267,7 +267,7 @@ class BaseCache:
     @API.aiocache_enabled(fake_return=True)
     @API.timeout
     @API.plugins
-    async def multi_set(self, pairs, ttl=sentinel, dumps_fn=None, namespace=None, _conn=None):
+    async def multi_set(self, pairs, ttl=SENTINEL, dumps_fn=None, namespace=None, _conn=None):
         """
         Stores multiple values in the given keys.
 
@@ -476,7 +476,7 @@ class BaseCache:
         return key
 
     def _get_ttl(self, ttl):
-        return ttl if ttl is not sentinel else self.ttl
+        return ttl if ttl is not SENTINEL else self.ttl
 
     def get_connection(self):
         return _Conn(self)

--- a/aiocache/base.py
+++ b/aiocache/base.py
@@ -9,6 +9,8 @@ from aiocache import serializers
 
 logger = logging.getLogger(__file__)
 
+sentinel = object()
+
 
 class API:
 
@@ -91,6 +93,8 @@ class BaseCache:
         list.
     :param namespace: string to use as default prefix for the key used in all operations of
         the backend. Default is None
+    :param ttl: int the expiration time in seconds to use as a default in all operations of
+        the backend. It can be overriden in the specific calls.
     :param key_builder: alternative callable to build the key. Receives the key and the namespace as
         params and should return something that can be used as key by the underlying backend.
     :param timeout: int or float in seconds specifying maximum timeout for the operations to last.
@@ -99,9 +103,10 @@ class BaseCache:
 
     def __init__(
             self, serializer=None, plugins=None,
-            namespace=None, key_builder=None, timeout=5):
+            namespace=None, ttl=None, key_builder=None, timeout=5):
         self.timeout = timeout
         self.namespace = namespace
+        self.ttl = ttl
         self.build_key = key_builder or self._build_key
 
         self._serializer = None
@@ -130,7 +135,7 @@ class BaseCache:
     @API.aiocache_enabled(fake_return=True)
     @API.timeout
     @API.plugins
-    async def add(self, key, value, ttl=None, dumps_fn=None, namespace=None, _conn=None):
+    async def add(self, key, value, ttl=sentinel, dumps_fn=None, namespace=None, _conn=None):
         """
         Stores the value in the given key with ttl if specified. Raises an error if the
         key already exists.
@@ -153,7 +158,7 @@ class BaseCache:
         dumps = dumps_fn or self._serializer.dumps
         ns_key = self.build_key(key, namespace=namespace)
 
-        await self._add(ns_key, dumps(value), ttl, _conn=_conn)
+        await self._add(ns_key, dumps(value), ttl=self._get_ttl(ttl), _conn=_conn)
 
         logger.debug("ADD %s %s (%.4f)s", ns_key, True, time.monotonic() - start)
         return True
@@ -228,7 +233,8 @@ class BaseCache:
     @API.timeout
     @API.plugins
     async def set(
-            self, key, value, ttl=None, dumps_fn=None, namespace=None, _cas_token=None, _conn=None):
+            self, key, value, ttl=sentinel, dumps_fn=None, namespace=None, _cas_token=None,
+            _conn=None):
         """
         Stores the value in the given key with ttl if specified
 
@@ -248,7 +254,8 @@ class BaseCache:
         dumps = dumps_fn or self._serializer.dumps
         ns_key = self.build_key(key, namespace=namespace)
 
-        res = await self._set(ns_key, dumps(value), ttl=ttl, _cas_token=_cas_token, _conn=_conn)
+        res = await self._set(
+            ns_key, dumps(value), ttl=self._get_ttl(ttl), _cas_token=_cas_token, _conn=_conn)
 
         logger.debug("SET %s %d (%.4f)s", ns_key, True, time.monotonic() - start)
         return res
@@ -260,7 +267,7 @@ class BaseCache:
     @API.aiocache_enabled(fake_return=True)
     @API.timeout
     @API.plugins
-    async def multi_set(self, pairs, ttl=None, dumps_fn=None, namespace=None, _conn=None):
+    async def multi_set(self, pairs, ttl=sentinel, dumps_fn=None, namespace=None, _conn=None):
         """
         Stores multiple values in the given keys.
 
@@ -282,7 +289,7 @@ class BaseCache:
         for key, value in pairs:
             tmp_pairs.append((self.build_key(key, namespace=namespace), dumps(value)))
 
-        await self._multi_set(tmp_pairs, ttl, _conn=_conn)
+        await self._multi_set(tmp_pairs, ttl=self._get_ttl(ttl), _conn=_conn)
 
         logger.debug(
             "MULTI_SET %s %d (%.4f)s",
@@ -467,6 +474,9 @@ class BaseCache:
         if self.namespace is not None:
             return "{}{}".format(self.namespace, key)
         return key
+
+    def _get_ttl(self, ttl):
+        return ttl if ttl is not sentinel else self.ttl
 
     def get_connection(self):
         return _Conn(self)

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -106,10 +106,7 @@ class cached:
 
     async def set_in_cache(self, key, value):
         try:
-            kwargs = {}
-            if self.ttl is not SENTINEL:
-                kwargs['ttl'] = self.ttl
-            await self.cache.set(key, value, **kwargs)
+            await self.cache.set(key, value, ttl=self.ttl)
         except Exception:
             logger.exception("Couldn't set %s in key %s, unexpected error", value, key)
 
@@ -295,11 +292,8 @@ class multi_cached:
 
     async def set_in_cache(self, result, fn_args, fn_kwargs):
         try:
-            kwargs = {}
-            if self.ttl is not SENTINEL:
-                kwargs['ttl'] = self.ttl
             await self.cache.multi_set(
                 [(self.key_builder(k, *fn_args, **fn_kwargs), v) for k, v in result.items()],
-                **kwargs)
+                ttl=self.ttl)
         except Exception:
             logger.exception("Couldn't set %s, unexpected error", result)

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -3,7 +3,7 @@ import functools
 import logging
 
 from aiocache import SimpleMemoryCache, caches
-from aiocache.base import sentinel
+from aiocache.base import SENTINEL
 from aiocache.lock import RedLock
 
 
@@ -43,7 +43,7 @@ class cached:
     """
 
     def __init__(
-            self, ttl=sentinel, key=None, key_builder=None, cache=SimpleMemoryCache,
+            self, ttl=SENTINEL, key=None, key_builder=None, cache=SimpleMemoryCache,
             serializer=None, plugins=None, alias=None, noself=False, **kwargs):
         self.ttl = ttl
         self.key = key
@@ -107,7 +107,7 @@ class cached:
     async def set_in_cache(self, key, value):
         try:
             kwargs = {}
-            if self.ttl is not sentinel:
+            if self.ttl is not SENTINEL:
                 kwargs['ttl'] = self.ttl
             await self.cache.set(key, value, **kwargs)
         except Exception:
@@ -216,7 +216,7 @@ class multi_cached:
     """
 
     def __init__(
-            self, keys_from_attr, key_builder=None, ttl=sentinel, cache=SimpleMemoryCache,
+            self, keys_from_attr, key_builder=None, ttl=SENTINEL, cache=SimpleMemoryCache,
             serializer=None, plugins=None, alias=None, **kwargs):
         self.keys_from_attr = keys_from_attr
         self.key_builder = key_builder or (lambda key, *args, **kwargs: key)
@@ -296,7 +296,7 @@ class multi_cached:
     async def set_in_cache(self, result, fn_args, fn_kwargs):
         try:
             kwargs = {}
-            if self.ttl is not sentinel:
+            if self.ttl is not SENTINEL:
                 kwargs['ttl'] = self.ttl
             await self.cache.multi_set(
                 [(self.key_builder(k, *fn_args, **fn_kwargs), v) for k, v in result.items()],

--- a/tests/ut/test_base.py
+++ b/tests/ut/test_base.py
@@ -231,92 +231,118 @@ class TestBaseCache:
         cache = BaseCache(key_builder=lambda key, namespace: 'x')
         assert cache.build_key(pytest.KEY, 'namespace') == 'x'
 
-    @pytest.fixture
-    def set_test_ttl(self, base_cache):
-        base_cache.ttl = 10
-        yield
-        base_cache.ttl = None
-
     @pytest.mark.asyncio
-    async def test_add_ttl_default(self, set_test_ttl, base_cache):
+    async def test_add_ttl_cache_default(self, base_cache):
         base_cache._add = CoroutineMock()
 
         await base_cache.add(pytest.KEY, "value")
 
-        assert base_cache._add.call_count == 1
-        assert base_cache._add.call_args[1]['ttl'] == 10
+        base_cache._add.assert_called_once_with(pytest.KEY, "value", _conn=None, ttl=None)
 
     @pytest.mark.asyncio
-    async def test_add_ttl_overriden(self, set_test_ttl, base_cache):
+    async def test_add_ttl_default(self, base_cache):
+        base_cache.ttl = 10
+        base_cache._add = CoroutineMock()
+
+        await base_cache.add(pytest.KEY, "value")
+
+        base_cache._add.assert_called_once_with(pytest.KEY, "value", _conn=None, ttl=10)
+
+    @pytest.mark.asyncio
+    async def test_add_ttl_overriden(self, base_cache):
+        base_cache.ttl = 10
         base_cache._add = CoroutineMock()
 
         await base_cache.add(pytest.KEY, "value", ttl=20)
 
-        assert base_cache._add.call_count == 1
-        assert base_cache._add.call_args[1]['ttl'] == 20
+        base_cache._add.assert_called_once_with(pytest.KEY, "value", _conn=None, ttl=20)
 
     @pytest.mark.asyncio
-    async def test_add_ttl_none(self, set_test_ttl, base_cache):
+    async def test_add_ttl_none(self, base_cache):
+        base_cache.ttl = 10
         base_cache._add = CoroutineMock()
 
         await base_cache.add(pytest.KEY, "value", ttl=None)
 
-        assert base_cache._add.call_count == 1
-        assert base_cache._add.call_args[1]['ttl'] is None
+        base_cache._add.assert_called_once_with(pytest.KEY, "value", _conn=None, ttl=None)
 
     @pytest.mark.asyncio
-    async def test_set_ttl_default(self, set_test_ttl, base_cache):
+    async def test_set_ttl_cache_default(self, base_cache):
         base_cache._set = CoroutineMock()
 
         await base_cache.set(pytest.KEY, "value")
 
-        assert base_cache._set.call_count == 1
-        assert base_cache._set.call_args[1]['ttl'] == 10
+        base_cache._set.assert_called_once_with(
+            pytest.KEY, "value", _cas_token=None, _conn=None, ttl=None)
 
     @pytest.mark.asyncio
-    async def test_set_ttl_overriden(self, set_test_ttl, base_cache):
+    async def test_set_ttl_default(self, base_cache):
+        base_cache.ttl = 10
+        base_cache._set = CoroutineMock()
+
+        await base_cache.set(pytest.KEY, "value")
+
+        base_cache._set.assert_called_once_with(
+            pytest.KEY, "value", _cas_token=None, _conn=None, ttl=10)
+
+    @pytest.mark.asyncio
+    async def test_set_ttl_overriden(self, base_cache):
+        base_cache.ttl = 10
         base_cache._set = CoroutineMock()
 
         await base_cache.set(pytest.KEY, "value", ttl=20)
 
-        assert base_cache._set.call_count == 1
-        assert base_cache._set.call_args[1]['ttl'] == 20
+        base_cache._set.assert_called_once_with(
+            pytest.KEY, "value", _cas_token=None, _conn=None, ttl=20)
 
     @pytest.mark.asyncio
-    async def test_set_ttl_none(self, set_test_ttl, base_cache):
+    async def test_set_ttl_none(self, base_cache):
+        base_cache.ttl = 10
         base_cache._set = CoroutineMock()
 
         await base_cache.set(pytest.KEY, "value", ttl=None)
 
-        assert base_cache._set.call_count == 1
-        assert base_cache._set.call_args[1]['ttl'] is None
+        base_cache._set.assert_called_once_with(
+            pytest.KEY, "value", _cas_token=None, _conn=None, ttl=None)
 
     @pytest.mark.asyncio
-    async def test_multi_set_ttl_default(self, set_test_ttl, base_cache):
+    async def test_multi_set_ttl_cache_default(self, base_cache):
         base_cache._multi_set = CoroutineMock()
 
         await base_cache.multi_set([[pytest.KEY, "value"], [pytest.KEY_1, "value1"]])
 
-        assert base_cache._multi_set.call_count == 1
-        assert base_cache._multi_set.call_args[1]['ttl'] == 10
+        base_cache._multi_set.assert_called_once_with(
+            [(pytest.KEY, "value"), (pytest.KEY_1, "value1")], _conn=None, ttl=None)
 
     @pytest.mark.asyncio
-    async def test_multi_set_ttl_overriden(self, set_test_ttl, base_cache):
+    async def test_multi_set_ttl_default(self, base_cache):
+        base_cache.ttl = 10
+        base_cache._multi_set = CoroutineMock()
+
+        await base_cache.multi_set([[pytest.KEY, "value"], [pytest.KEY_1, "value1"]])
+
+        base_cache._multi_set.assert_called_once_with(
+            [(pytest.KEY, "value"), (pytest.KEY_1, "value1")], _conn=None, ttl=10)
+
+    @pytest.mark.asyncio
+    async def test_multi_set_ttl_overriden(self, base_cache):
+        base_cache.ttl = 10
         base_cache._multi_set = CoroutineMock()
 
         await base_cache.multi_set([[pytest.KEY, "value"], [pytest.KEY_1, "value1"]], ttl=20)
 
-        assert base_cache._multi_set.call_count == 1
-        assert base_cache._multi_set.call_args[1]['ttl'] == 20
+        base_cache._multi_set.assert_called_once_with(
+            [(pytest.KEY, "value"), (pytest.KEY_1, "value1")], _conn=None, ttl=20)
 
     @pytest.mark.asyncio
-    async def test_multi_set_ttl_none(self, set_test_ttl, base_cache):
+    async def test_multi_set_ttl_none(self, base_cache):
+        base_cache.ttl = 10
         base_cache._multi_set = CoroutineMock()
 
         await base_cache.multi_set([[pytest.KEY, "value"], [pytest.KEY_1, "value1"]], ttl=None)
 
-        assert base_cache._multi_set.call_count == 1
-        assert base_cache._multi_set.call_args[1]['ttl'] is None
+        base_cache._multi_set.assert_called_once_with(
+            [(pytest.KEY, "value"), (pytest.KEY_1, "value1")], _conn=None, ttl=None)
 
 
 class TestCache:

--- a/tests/ut/test_base.py
+++ b/tests/ut/test_base.py
@@ -231,6 +231,93 @@ class TestBaseCache:
         cache = BaseCache(key_builder=lambda key, namespace: 'x')
         assert cache.build_key(pytest.KEY, 'namespace') == 'x'
 
+    @pytest.fixture
+    def set_test_ttl(self, base_cache):
+        base_cache.ttl = 10
+        yield
+        base_cache.ttl = None
+
+    @pytest.mark.asyncio
+    async def test_add_ttl_default(self, set_test_ttl, base_cache):
+        base_cache._add = CoroutineMock()
+
+        await base_cache.add(pytest.KEY, "value")
+
+        assert base_cache._add.call_count == 1
+        assert base_cache._add.call_args[1]['ttl'] == 10
+
+    @pytest.mark.asyncio
+    async def test_add_ttl_overriden(self, set_test_ttl, base_cache):
+        base_cache._add = CoroutineMock()
+
+        await base_cache.add(pytest.KEY, "value", ttl=20)
+
+        assert base_cache._add.call_count == 1
+        assert base_cache._add.call_args[1]['ttl'] == 20
+
+    @pytest.mark.asyncio
+    async def test_add_ttl_none(self, set_test_ttl, base_cache):
+        base_cache._add = CoroutineMock()
+
+        await base_cache.add(pytest.KEY, "value", ttl=None)
+
+        assert base_cache._add.call_count == 1
+        assert base_cache._add.call_args[1]['ttl'] is None
+
+    @pytest.mark.asyncio
+    async def test_set_ttl_default(self, set_test_ttl, base_cache):
+        base_cache._set = CoroutineMock()
+
+        await base_cache.set(pytest.KEY, "value")
+
+        assert base_cache._set.call_count == 1
+        assert base_cache._set.call_args[1]['ttl'] == 10
+
+    @pytest.mark.asyncio
+    async def test_set_ttl_overriden(self, set_test_ttl, base_cache):
+        base_cache._set = CoroutineMock()
+
+        await base_cache.set(pytest.KEY, "value", ttl=20)
+
+        assert base_cache._set.call_count == 1
+        assert base_cache._set.call_args[1]['ttl'] == 20
+
+    @pytest.mark.asyncio
+    async def test_set_ttl_none(self, set_test_ttl, base_cache):
+        base_cache._set = CoroutineMock()
+
+        await base_cache.set(pytest.KEY, "value", ttl=None)
+
+        assert base_cache._set.call_count == 1
+        assert base_cache._set.call_args[1]['ttl'] is None
+
+    @pytest.mark.asyncio
+    async def test_multi_set_ttl_default(self, set_test_ttl, base_cache):
+        base_cache._multi_set = CoroutineMock()
+
+        await base_cache.multi_set([[pytest.KEY, "value"], [pytest.KEY_1, "value1"]])
+
+        assert base_cache._multi_set.call_count == 1
+        assert base_cache._multi_set.call_args[1]['ttl'] == 10
+
+    @pytest.mark.asyncio
+    async def test_multi_set_ttl_overriden(self, set_test_ttl, base_cache):
+        base_cache._multi_set = CoroutineMock()
+
+        await base_cache.multi_set([[pytest.KEY, "value"], [pytest.KEY_1, "value1"]], ttl=20)
+
+        assert base_cache._multi_set.call_count == 1
+        assert base_cache._multi_set.call_args[1]['ttl'] == 20
+
+    @pytest.mark.asyncio
+    async def test_multi_set_ttl_none(self, set_test_ttl, base_cache):
+        base_cache._multi_set = CoroutineMock()
+
+        await base_cache.multi_set([[pytest.KEY, "value"], [pytest.KEY_1, "value1"]], ttl=None)
+
+        assert base_cache._multi_set.call_count == 1
+        assert base_cache._multi_set.call_args[1]['ttl'] is None
+
 
 class TestCache:
     """
@@ -294,7 +381,7 @@ class TestCache:
         await mock_cache.add(pytest.KEY, "value", ttl=2)
 
         mock_cache._add.assert_called_with(
-            mock_cache._build_key(pytest.KEY), ANY, 2, _conn=ANY)
+            mock_cache._build_key(pytest.KEY), ANY, ttl=2, _conn=ANY)
         assert mock_cache.plugins[0].pre_add.call_count == 1
         assert mock_cache.plugins[0].post_add.call_count == 1
 
@@ -328,7 +415,7 @@ class TestCache:
 
         mock_cache._multi_set.assert_called_with([
             (mock_cache._build_key(pytest.KEY), ANY),
-            (mock_cache._build_key(pytest.KEY_1), ANY)], 2, _conn=ANY)
+            (mock_cache._build_key(pytest.KEY_1), ANY)], ttl=2, _conn=ANY)
         assert mock_cache.plugins[0].pre_multi_set.call_count == 1
         assert mock_cache.plugins[0].post_multi_set.call_count == 1
 

--- a/tests/ut/test_decorators.py
+++ b/tests/ut/test_decorators.py
@@ -131,7 +131,7 @@ class TestCached:
     @pytest.mark.asyncio
     async def test_set_calls_set(self, decorator, decorator_call):
         await decorator.set_in_cache("key", "value")
-        decorator.cache.set.assert_called_with("key", "value", ttl=None)
+        decorator.cache.set.assert_called_with("key", "value")
 
     @pytest.mark.asyncio
     async def test_set_calls_set_ttl(self, decorator, decorator_call):
@@ -257,7 +257,7 @@ class TestCachedStampede:
             assert lock.__aenter__.call_count == 1
             assert lock.__aexit__.call_count == 1
             decorator.cache.set.assert_called_with(
-                "stub()[('value', 'value')]", "value", ttl=None)
+                "stub()[('value', 'value')]", "value")
             stub.assert_called_once_with(value="value")
 
     @pytest.mark.asyncio
@@ -276,7 +276,7 @@ class TestCachedStampede:
             assert lock2.__aenter__.call_count == 1
             assert lock2.__aexit__.call_count == 1
             decorator.cache.set.assert_called_with(
-                "stub()[('value', 'value')]", "value", ttl=None)
+                "stub()[('value', 'value')]", "value")
             assert stub.call_count == 1
 
 
@@ -441,7 +441,7 @@ class TestMultiCached:
         call_args = decorator.cache.multi_set.call_args[0][0]
         assert ('a', 1) in call_args
         assert ('b', 2) in call_args
-        call_args = decorator.cache.multi_set.call_args[1]['ttl'] is None
+        assert 'ttl' not in decorator.cache.multi_set.call_args[1]
 
     @pytest.mark.asyncio
     async def test_set_in_cache_with_ttl(self, decorator, decorator_call):

--- a/tests/ut/test_decorators.py
+++ b/tests/ut/test_decorators.py
@@ -6,7 +6,7 @@ import inspect
 
 from asynctest import MagicMock, CoroutineMock, ANY, patch
 
-from aiocache.base import BaseCache
+from aiocache.base import BaseCache, SENTINEL
 from aiocache import cached, cached_stampede, multi_cached, SimpleMemoryCache
 from aiocache.lock import RedLock
 from aiocache.decorators import _get_args_dict
@@ -131,7 +131,7 @@ class TestCached:
     @pytest.mark.asyncio
     async def test_set_calls_set(self, decorator, decorator_call):
         await decorator.set_in_cache("key", "value")
-        decorator.cache.set.assert_called_with("key", "value")
+        decorator.cache.set.assert_called_with("key", "value", ttl=SENTINEL)
 
     @pytest.mark.asyncio
     async def test_set_calls_set_ttl(self, decorator, decorator_call):
@@ -257,7 +257,7 @@ class TestCachedStampede:
             assert lock.__aenter__.call_count == 1
             assert lock.__aexit__.call_count == 1
             decorator.cache.set.assert_called_with(
-                "stub()[('value', 'value')]", "value")
+                "stub()[('value', 'value')]", "value", ttl=SENTINEL)
             stub.assert_called_once_with(value="value")
 
     @pytest.mark.asyncio
@@ -276,7 +276,7 @@ class TestCachedStampede:
             assert lock2.__aenter__.call_count == 1
             assert lock2.__aexit__.call_count == 1
             decorator.cache.set.assert_called_with(
-                "stub()[('value', 'value')]", "value")
+                "stub()[('value', 'value')]", "value", ttl=SENTINEL)
             assert stub.call_count == 1
 
 
@@ -441,7 +441,7 @@ class TestMultiCached:
         call_args = decorator.cache.multi_set.call_args[0][0]
         assert ('a', 1) in call_args
         assert ('b', 2) in call_args
-        assert 'ttl' not in decorator.cache.multi_set.call_args[1]
+        assert decorator.cache.multi_set.call_args[1]['ttl'] is SENTINEL
 
     @pytest.mark.asyncio
     async def test_set_in_cache_with_ttl(self, decorator, decorator_call):

--- a/tests/ut/test_factory.py
+++ b/tests/ut/test_factory.py
@@ -68,6 +68,7 @@ class TestCacheHandler:
                 'cache': "aiocache.RedisCache",
                 'endpoint': "127.0.0.10",
                 'port': 6378,
+                'ttl': 10,
                 'serializer': {
                     'class': "aiocache.serializers.PickleSerializer",
                     'encoding': 'encoding'
@@ -83,6 +84,7 @@ class TestCacheHandler:
         assert isinstance(cache, RedisCache)
         assert cache.endpoint == "127.0.0.10"
         assert cache.port == 6378
+        assert cache.ttl == 10
         assert isinstance(cache.serializer, PickleSerializer)
         assert cache.serializer.encoding == 'encoding'
         assert len(cache.plugins) == 2


### PR DESCRIPTION
As discussed in #387 `ttl` was the only parameter not allowed by default in the cache class. Caches instances that have this parameter in the constructor will use it by default in all the calls, unless a specific parameter is passed.