### PR TITLE
Add interface for backend and small other fixes

### DIFF
--- a/aiocache/backends/__init__.py
+++ b/aiocache/backends/__init__.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+
+
+class BaseBackend(ABC):
+    """
+    Abstract class for implementation cache backend
+    """
+
+    @abstractmethod
+    async def _get(self, key, encoding="utf-8", _conn=None):
+        pass
+
+    @abstractmethod
+    async def _gets(self, key, encoding="utf-8", _conn=None):
+        pass
+
+    @abstractmethod
+    async def _multi_get(self, keys, encoding="utf-8", _conn=None):
+        pass
+
+    @abstractmethod
+    async def _set(self, key, value, ttl=None, _cas_token=None, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _multi_set(self, pairs, ttl=None, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _add(self, key, value, ttl=None, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _exists(self, key, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _increment(self, key, delta, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _expire(self, key, ttl, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _delete(self, key, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _clear(self, namespace=None, _conn=None):
+        pass
+
+    @abstractmethod
+    async def _raw(self, command, *args, encoding="utf-8", _conn=None, **kwargs):
+        pass
+
+    @abstractmethod
+    async def _redlock_release(self, key, value):
+        pass

--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -1,11 +1,12 @@
 import asyncio
 import aiomcache
 
+from aiocache.backends import BaseBackend
 from aiocache.base import BaseCache
 from aiocache.serializers import JsonSerializer
 
 
-class MemcachedBackend:
+class MemcachedBackend(BaseBackend):
     def __init__(self, endpoint="127.0.0.1", port=11211, pool_size=2, loop=None, **kwargs):
         super().__init__(**kwargs)
         self.endpoint = endpoint

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -1,10 +1,11 @@
 import asyncio
 
+from aiocache.backends import BaseBackend
 from aiocache.base import BaseCache
 from aiocache.serializers import NullSerializer
 
 
-class SimpleMemoryBackend:
+class SimpleMemoryBackend(BaseBackend):
     """
     Wrapper around dict operations to use it as a cache backend
     """

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -4,6 +4,7 @@ import functools
 
 import aioredis
 
+from aiocache.backends import BaseBackend
 from aiocache.base import BaseCache
 from aiocache.serializers import JsonSerializer
 
@@ -28,7 +29,7 @@ def conn(func):
     return wrapper
 
 
-class RedisBackend:
+class RedisBackend(BaseBackend):
 
     RELEASE_SCRIPT = (
         "if redis.call('get',KEYS[1]) == ARGV[1] then"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,4 @@ source = aiocache
 [coverage:report]
 show_missing = true
 skip_covered = true
+exclude_lines = @abstract

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -61,4 +61,4 @@ def memcached_cache(event_loop):
 
 @pytest.fixture(params=["redis_cache", "memory_cache", "memcached_cache"])
 def cache(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)

--- a/tests/acceptance/test_serializers.py
+++ b/tests/acceptance/test_serializers.py
@@ -1,14 +1,11 @@
 import pytest
 import random
+import pickle
 
 try:
     import ujson as json
 except ImportError:
     import json
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
 
 from marshmallow import fields, Schema, post_load
 


### PR DESCRIPTION
Add Backend Interface.
getfuncargvalue deprecated, replace with getfixturevalue.
Remove cPickle in test, because in python3.x imported by default.