### PR TITLE
Catch KeyError when the lock is already released

### DIFF
--- a/aiocache/lock.py
+++ b/aiocache/lock.py
@@ -94,7 +94,10 @@ class RedLock:
     async def _release(self):
         removed = await self.client._redlock_release(self.key, self._value)
         if removed:
-            RedLock._EVENTS.pop(self.key).set()
+            try:
+                RedLock._EVENTS.pop(self.key).set()
+            except KeyError:  # lock was already released
+                pass
 
 
 class OptimisticLock:

--- a/tests/ut/test_serializers.py
+++ b/tests/ut/test_serializers.py
@@ -50,7 +50,7 @@ class TestNullSerializer:
         assert NullSerializer().dumps(obj) is obj
 
     def test_loads(self):
-        assert NullSerializer().loads("hi") is "hi"
+        assert NullSerializer().loads("hi") == "hi"
 
 
 class TestStringSerializer:


### PR DESCRIPTION
When there are many calls waiting, there could be a race condition when releasing the lock and I encounter `KeyError` when trying to pop the `asyncio.Event`.