### PR TITLE
Extend and improve usage of Cache class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Or as a decorator
 
     from collections import namedtuple
 
-    from aiocache import cached, Cache, RedisCache
+    from aiocache import cached, Cache
     from aiocache.serializers import PickleSerializer
     # With this we can store python objects in backends like Redis!
 
@@ -85,7 +85,7 @@ Or as a decorator
 
 
     @cached(
-        ttl=10, cache=RedisCache, key="key", serializer=PickleSerializer(), port=6379, namespace="main")
+        ttl=10, cache=Cache.REDIS, key="key", serializer=PickleSerializer(), port=6379, namespace="main")
     async def cached_call():
         print("Sleeping for three seconds zzzz.....")
         await asyncio.sleep(3)

--- a/aiocache/__init__.py
+++ b/aiocache/__init__.py
@@ -6,7 +6,7 @@ from ._version import __version__
 
 logger = logging.getLogger(__name__)
 
-AIOCACHE_CACHES = {"memory": SimpleMemoryCache}
+AIOCACHE_CACHES = {SimpleMemoryCache.NAME: SimpleMemoryCache}
 
 
 try:
@@ -16,7 +16,7 @@ except ImportError:
 else:
     from aiocache.backends.redis import RedisCache
 
-    AIOCACHE_CACHES["redis"] = RedisCache
+    AIOCACHE_CACHES[RedisCache.NAME] = RedisCache
     del aioredis
 
 try:
@@ -26,7 +26,7 @@ except ImportError:
 else:
     from aiocache.backends.memcached import MemcachedCache
 
-    AIOCACHE_CACHES["memcached"] = MemcachedCache
+    AIOCACHE_CACHES[MemcachedCache.NAME] = MemcachedCache
     del aiomcache
 
 

--- a/aiocache/backends/memcached.py
+++ b/aiocache/backends/memcached.py
@@ -118,10 +118,6 @@ class MemcachedBackend:
     async def _close(self, *args, _conn=None, **kwargs):
         await self.client.close()
 
-    @classmethod
-    def parse_uri_path(self, path):
-        return {}
-
 
 class MemcachedCache(MemcachedBackend, BaseCache):
     """
@@ -142,9 +138,15 @@ class MemcachedCache(MemcachedBackend, BaseCache):
     :param pool_size: int size for memcached connections pool. Default is 2.
     """
 
+    NAME = "memcached"
+
     def __init__(self, serializer=None, **kwargs):
         super().__init__(**kwargs)
         self.serializer = serializer or JsonSerializer()
+
+    @classmethod
+    def parse_uri_path(self, path):
+        return {}
 
     def _build_key(self, key, namespace=None):
         ns_key = super()._build_key(key, namespace=namespace).replace(" ", "_")

--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -106,10 +106,6 @@ class SimpleMemoryBackend:
 
         return 0
 
-    @classmethod
-    def parse_uri_path(cls, path):
-        return {}
-
 
 class SimpleMemoryCache(SimpleMemoryBackend, BaseCache):
     """
@@ -127,6 +123,12 @@ class SimpleMemoryCache(SimpleMemoryBackend, BaseCache):
         By default its 5.
     """
 
+    NAME = "memory"
+
     def __init__(self, serializer=None, **kwargs):
         super().__init__(**kwargs)
         self.serializer = serializer or NullSerializer()
+
+    @classmethod
+    def parse_uri_path(cls, path):
+        return {}

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -220,22 +220,6 @@ class RedisBackend:
 
             return self._pool
 
-    @classmethod
-    def parse_uri_path(self, path):
-        """
-        Given a uri path, return the Redis specific configuration
-        options in that path string according to iana definition
-        http://www.iana.org/assignments/uri-schemes/prov/redis
-
-        :param path: string containing the path. Example: "/0"
-        :return: mapping containing the options. Example: {"db": "0"}
-        """
-        options = {}
-        db, *_ = path[1:].split("/")
-        if db:
-            options["db"] = db
-        return options
-
 
 class RedisCache(RedisBackend, BaseCache):
     """
@@ -261,9 +245,27 @@ class RedisCache(RedisBackend, BaseCache):
         only for aioredis>=1. Default is None
     """
 
+    NAME = "redis"
+
     def __init__(self, serializer=None, **kwargs):
         super().__init__(**kwargs)
         self.serializer = serializer or JsonSerializer()
+
+    @classmethod
+    def parse_uri_path(self, path):
+        """
+        Given a uri path, return the Redis specific configuration
+        options in that path string according to iana definition
+        http://www.iana.org/assignments/uri-schemes/prov/redis
+
+        :param path: string containing the path. Example: "/0"
+        :return: mapping containing the options. Example: {"db": "0"}
+        """
+        options = {}
+        db, *_ = path[1:].split("/")
+        if db:
+            options["db"] = db
+        return options
 
     def _build_key(self, key, namespace=None):
         if namespace is not None:

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -2,7 +2,7 @@ import inspect
 import functools
 import logging
 
-from aiocache import SimpleMemoryCache, caches
+from aiocache import Cache, caches
 from aiocache.base import SENTINEL
 from aiocache.lock import RedLock
 
@@ -16,7 +16,7 @@ class cached:
     The cache is available in the function object as ``<function_name>.cache``.
 
     In some cases you will need to send more args to configure the cache object.
-    An example would be endpoint and port for the RedisCache. You can send those args as
+    An example would be endpoint and port for the Redis cache. You can send those args as
     kwargs and they will be propagated accordingly.
 
     Only one cache instance is created per decorated call. If you expect high concurrency of calls
@@ -32,7 +32,7 @@ class cached:
     :param key_builder: Callable that allows to build the function dynamically. It receives
         the function plus same args and kwargs passed to the function.
     :param cache: cache class to use when calling the ``set``/``get`` operations.
-        Default is ``aiocache.SimpleMemoryCache``.
+        Default is :class:`aiocache.SimpleMemoryCache`.
     :param serializer: serializer instance to use when calling the ``dumps``/``loads``.
         If its None, default one from the cache backend is used.
     :param plugins: list plugins to use when calling the cmd hooks
@@ -50,7 +50,7 @@ class cached:
         ttl=SENTINEL,
         key=None,
         key_builder=None,
-        cache=SimpleMemoryCache,
+        cache=Cache.MEMORY,
         serializer=None,
         plugins=None,
         alias=None,
@@ -139,7 +139,7 @@ class cached_stampede(cached):
     while avoids for cache stampede effects.
 
     In some cases you will need to send more args to configure the cache object.
-    An example would be endpoint and port for the RedisCache. You can send those args as
+    An example would be endpoint and port for the Redis cache. You can send those args as
     kwargs and they will be propagated accordingly.
 
     Only one cache instance is created per decorated function. If you expect high concurrency
@@ -154,7 +154,7 @@ class cached_stampede(cached):
         + function_name + args + kwargs
     :param key_from_attr: str arg or kwarg name from the function to use as a key.
     :param cache: cache class to use when calling the ``set``/``get`` operations.
-        Default is ``aiocache.SimpleMemoryCache``.
+        Default is :class:`aiocache.SimpleMemoryCache`.
     :param serializer: serializer instance to use when calling the ``dumps``/``loads``.
         Default is JsonSerializer.
     :param plugins: list plugins to use when calling the cmd hooks
@@ -189,7 +189,7 @@ class cached_stampede(cached):
         return result
 
 
-def _get_cache(cache=SimpleMemoryCache, serializer=None, plugins=None, **cache_kwargs):
+def _get_cache(cache=Cache.MEMORY, serializer=None, plugins=None, **cache_kwargs):
     return cache(serializer=serializer, plugins=plugins, **cache_kwargs)
 
 
@@ -231,7 +231,7 @@ class multi_cached:
         Receives the key the function and same args and kwargs as the called function.
     :param ttl: int seconds to store the keys. Default is 0 which means no expiration.
     :param cache: cache class to use when calling the ``multi_set``/``multi_get`` operations.
-        Default is ``aiocache.SimpleMemoryCache``.
+        Default is :class:`aiocache.SimpleMemoryCache`.
     :param serializer: serializer instance to use when calling the ``dumps``/``loads``.
         If its None, default one from the cache backend is used.
     :param plugins: plugins to use when calling the cmd hooks
@@ -246,7 +246,7 @@ class multi_cached:
         keys_from_attr,
         key_builder=None,
         ttl=SENTINEL,
-        cache=SimpleMemoryCache,
+        cache=Cache.MEMORY,
         serializer=None,
         plugins=None,
         alias=None,

--- a/aiocache/serializers/serializers.py
+++ b/aiocache/serializers/serializers.py
@@ -37,7 +37,8 @@ class NullSerializer(BaseSerializer):
     """
     This serializer does nothing. Its only recommended to be used by
     :class:`aiocache.SimpleMemoryCache` because for other backends it will
-    produce incompatible data unless you work only with str types.
+    produce incompatible data unless you work only with str types because it
+    store data as is.
 
     DISCLAIMER: Be careful with mutable types and memory storage. The following
     behavior is considered normal (same as ``functools.lru_cache``)::

--- a/docs/serializers.rst
+++ b/docs/serializers.rst
@@ -7,9 +7,9 @@ Serializers can be attached to backends in order to serialize/deserialize data s
 
 To use a specific serializer::
 
-    >>> from aiocache import SimpleMemoryCache
+    >>> from aiocache import Cache
     >>> from aiocache.serializers import PickleSerializer
-    cache = SimpleMemoryCache(serializer=PickleSerializer())
+    cache = Cache(Cache.MEMORY, serializer=PickleSerializer())
 
 Currently the following are built in:
 

--- a/examples/cached_alias_config.py
+++ b/examples/cached_alias_config.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from aiocache import caches, SimpleMemoryCache, RedisCache
+from aiocache import caches, Cache
 from aiocache.serializers import StringSerializer, PickleSerializer
 
 caches.set_config({
@@ -31,7 +31,7 @@ async def default_cache():
     await cache.set("key", "value")
 
     assert await cache.get("key") == "value"
-    assert isinstance(cache, SimpleMemoryCache)
+    assert isinstance(cache, Cache.MEMORY)
     assert isinstance(cache.serializer, StringSerializer)
 
 
@@ -42,7 +42,7 @@ async def alt_cache():
     await cache.set("key", "value")
 
     assert await cache.get("key") == "value"
-    assert isinstance(cache, RedisCache)
+    assert isinstance(cache, Cache.REDIS)
     assert isinstance(cache.serializer, PickleSerializer)
     assert len(cache.plugins) == 2
     assert cache.endpoint == "127.0.0.1"
@@ -56,7 +56,7 @@ def test_alias():
     loop.run_until_complete(default_cache())
     loop.run_until_complete(alt_cache())
 
-    cache = RedisCache()
+    cache = Cache(Cache.REDIS)
     loop.run_until_complete(cache.delete("key"))
     loop.run_until_complete(cache.close())
 

--- a/examples/cached_decorator.py
+++ b/examples/cached_decorator.py
@@ -2,21 +2,21 @@ import asyncio
 
 from collections import namedtuple
 
-from aiocache import cached, RedisCache
+from aiocache import cached, Cache
 from aiocache.serializers import PickleSerializer
 
 Result = namedtuple('Result', "content, status")
 
 
 @cached(
-    ttl=10, cache=RedisCache, key="key", serializer=PickleSerializer(),
+    ttl=10, cache=Cache.REDIS, key="key", serializer=PickleSerializer(),
     port=6379, namespace="main")
 async def cached_call():
     return Result("content", 200)
 
 
 def test_cached():
-    cache = RedisCache(endpoint="127.0.0.1", port=6379, namespace="main")
+    cache = Cache(Cache.REDIS, endpoint="127.0.0.1", port=6379, namespace="main")
     loop = asyncio.get_event_loop()
     loop.run_until_complete(cached_call())
     assert loop.run_until_complete(cache.exists("key")) is True

--- a/examples/multicached_decorator.py
+++ b/examples/multicached_decorator.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from aiocache import multi_cached, RedisCache
+from aiocache import multi_cached, Cache
 
 DICT = {
     'a': "Z",
@@ -10,17 +10,17 @@ DICT = {
 }
 
 
-@multi_cached("ids", cache=RedisCache, namespace="main")
+@multi_cached("ids", cache=Cache.REDIS, namespace="main")
 async def multi_cached_ids(ids=None):
     return {id_: DICT[id_] for id_ in ids}
 
 
-@multi_cached("keys", cache=RedisCache, namespace="main")
+@multi_cached("keys", cache=Cache.REDIS, namespace="main")
 async def multi_cached_keys(keys=None):
     return {id_: DICT[id_] for id_ in keys}
 
 
-cache = RedisCache(endpoint="127.0.0.1", port=6379, namespace="main")
+cache = Cache(Cache.REDIS, endpoint="127.0.0.1", port=6379, namespace="main")
 
 
 def test_multi_cached():

--- a/tests/ut/backends/test_memcached.py
+++ b/tests/ut/backends/test_memcached.py
@@ -250,9 +250,6 @@ class TestMemcachedBackend:
         await memcached._close()
         assert memcached.client.close.call_count == 1
 
-    def test_parse_uri_path(self):
-        assert MemcachedBackend.parse_uri_path("/1/2/3") == {}
-
 
 class TestMemcachedCache:
     @pytest.fixture
@@ -261,11 +258,17 @@ class TestMemcachedCache:
         yield
         memcached_cache.namespace = None
 
+    def test_name(self):
+        assert MemcachedCache.NAME == "memcached"
+
     def test_inheritance(self):
         assert isinstance(MemcachedCache(), BaseCache)
 
     def test_default_serializer(self):
         assert isinstance(MemcachedCache().serializer, JsonSerializer)
+
+    def test_parse_uri_path(self):
+        assert MemcachedCache().parse_uri_path("/1/2/3") == {}
 
     @pytest.mark.parametrize(
         "namespace, expected",

--- a/tests/ut/backends/test_memory.py
+++ b/tests/ut/backends/test_memory.py
@@ -198,13 +198,16 @@ class TestSimpleMemoryBackend:
         SimpleMemoryBackend._cache.get.assert_called_with(pytest.KEY)
         assert SimpleMemoryBackend._cache.pop.call_count == 0
 
-    def test_parse_uri_path(self):
-        assert SimpleMemoryBackend.parse_uri_path("/1/2/3") == {}
-
 
 class TestSimpleMemoryCache:
+    def test_name(self):
+        assert SimpleMemoryCache.NAME == "memory"
+
     def test_inheritance(self):
         assert isinstance(SimpleMemoryCache(), BaseCache)
 
     def test_default_serializer(self):
         assert isinstance(SimpleMemoryCache().serializer, NullSerializer)
+
+    def test_parse_uri_path(self):
+        assert SimpleMemoryCache().parse_uri_path("/1/2/3") == {}

--- a/tests/ut/backends/test_redis.py
+++ b/tests/ut/backends/test_redis.py
@@ -339,12 +339,6 @@ class TestConn:
         await d(redis, "a", _conn=redis_connection)
         self.dummy.assert_called_with(redis, "a", _conn=redis_connection)
 
-    @pytest.mark.parametrize(
-        "path,expected", [("", {}), ("/", {}), ("/1", {"db": "1"}), ("/1/2/3", {"db": "1"})]
-    )
-    def test_parse_uri_path(self, path, expected):
-        assert RedisBackend.parse_uri_path(path) == expected
-
 
 class TestRedisCache:
     @pytest.fixture
@@ -353,11 +347,20 @@ class TestRedisCache:
         yield
         redis_cache.namespace = None
 
+    def test_name(self):
+        assert RedisCache.NAME == "redis"
+
     def test_inheritance(self):
         assert isinstance(RedisCache(), BaseCache)
 
     def test_default_serializer(self):
         assert isinstance(RedisCache().serializer, JsonSerializer)
+
+    @pytest.mark.parametrize(
+        "path,expected", [("", {}), ("/", {}), ("/1", {"db": "1"}), ("/1/2/3", {"db": "1"})]
+    )
+    def test_parse_uri_path(self, path, expected):
+        assert RedisCache().parse_uri_path(path) == expected
 
     @pytest.mark.parametrize(
         "namespace, expected",


### PR DESCRIPTION
Trying to push usage of `Cache.MEMORY` accessor like instead of accessing the constructor directly