### PR TITLE
Do not attempt clear for redis cache when no keys present

### DIFF
--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -184,7 +184,8 @@ class RedisBackend:
     async def _clear(self, namespace=None, _conn=None):
         if namespace:
             keys = await _conn.keys("{}:*".format(namespace))
-            await _conn.delete(*keys)
+            if keys:
+                await _conn.delete(*keys)
         else:
             await _conn.flushdb()
         return True


### PR DESCRIPTION
Previously, if there exists no keys in a specified namespace attempts to clear
the a redis backed cache would raise a TypeError. This change ensures that
a delete is not attempted in this scenario.