### PR TITLE
Raise RuntimeError if MsgPackSerializer is initialized without msgpack installed

### DIFF
--- a/aiocache/serializers/serializers.py
+++ b/aiocache/serializers/serializers.py
@@ -12,7 +12,8 @@ except ImportError:
 try:
     import msgpack
 except ImportError:
-    logger.warning("msgpack not installed, MsgPackSerializer unavailable")
+    msgpack = None
+    logger.debug("msgpack not installed, MsgPackSerializer unavailable")
 
 
 _NOT_SET = object()
@@ -163,6 +164,8 @@ class MsgPackSerializer(BaseSerializer):
     """
 
     def __init__(self, *args, use_list=True, **kwargs):
+        if not msgpack:
+            raise RuntimeError("msgpack not installed, MsgPackSerializer unavailable")
         self.use_list = use_list
         super().__init__(*args, **kwargs)
 

--- a/tests/ut/test_serializers.py
+++ b/tests/ut/test_serializers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from collections import namedtuple
+from unittest import mock
 
 from aiocache.serializers import (
     BaseSerializer,
@@ -137,6 +138,12 @@ class TestMsgPackSerializer:
         assert isinstance(serializer, BaseSerializer)
         assert serializer.DEFAULT_ENCODING == "utf-8"
         assert serializer.encoding == "utf-8"
+
+    def test_init_fails_if_msgpack_not_installed(self):
+        with mock.patch("aiocache.serializers.serializers.msgpack", None):
+            with pytest.raises(RuntimeError):
+                MsgPackSerializer()
+            assert JsonSerializer(), "Other serializers should still initialize"
 
     def test_init_use_list(self):
         serializer = MsgPackSerializer(use_list=True)


### PR DESCRIPTION
`msgpack` is an _optional_ dependency, however it calls `logger.warning("msgpack not installed, MsgPackSerializer unavailable")` if you import from `aiocache` without `msgpack` installed which is kind of annoying.

This PR downgrades the logging message from a `warning` to a `debug`, _but also_ raises a `RuntimeError` if someone tries to use `MsgPackSerializer` without `msgpack` installed (although [issue #378](https://github.com/argaen/aiocache/issues/378) made `MsgSerializer` dynamically importable, users can still import and use that serializer directly via `from aiocache.serializers.serializers import MsgPackSerializer`).

Let me know if you'd prefer this split into two PRs.