### PR TITLE
Fix TypeError on import all from aiocache

### DIFF
--- a/aiocache/__init__.py
+++ b/aiocache/__init__.py
@@ -40,6 +40,6 @@ __all__ = (
     "cached",
     "cached_stampede",
     "multi_cached",
-    *list(AIOCACHE_CACHES.values()),
+    *(c.__name__ for c in AIOCACHE_CACHES.values()),
     "__version__",
 )


### PR DESCRIPTION
Python 3.7.7

```python
from aiocache import *
```

Result:
```
TypeError: Item in aiocache.__all__ must be str, not type
```