### PR TITLE
ENH: create default_ttl variable

### DIFF
--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -14,6 +14,8 @@ class SimpleMemoryBackend:
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        # TODO: this is a super() option
+        self.default_ttl = kwargs.get("default_ttl", None)
 
     async def _get(self, key, encoding="utf-8", _conn=None):
         return SimpleMemoryBackend._cache.get(key)
@@ -25,6 +27,8 @@ class SimpleMemoryBackend:
         return [SimpleMemoryBackend._cache.get(key) for key in keys]
 
     async def _set(self, key, value, ttl=None, _cas_token=None, _conn=None):
+        if ttl is None:
+            ttl = self.default_ttl
         if _cas_token is not None and _cas_token != SimpleMemoryBackend._cache.get(key):
             return 0
 
@@ -38,11 +42,15 @@ class SimpleMemoryBackend:
         return True
 
     async def _multi_set(self, pairs, ttl=None, _conn=None):
+        if ttl is None:
+            ttl = self.default_ttl
         for key, value in pairs:
             await self._set(key, value, ttl=ttl)
         return True
 
     async def _add(self, key, value, ttl=None, _conn=None):
+        if ttl is None:
+            ttl = self.default_ttl
         if key in SimpleMemoryBackend._cache:
             raise ValueError("Key {} already exists, use .set to update the value".format(key))
 

--- a/aiocache/backends/redis.py
+++ b/aiocache/backends/redis.py
@@ -65,6 +65,8 @@ class RedisBackend:
         **kwargs
     ):
         super().__init__(**kwargs)
+        # TODO: this is a super() option
+        self.default_ttl = kwargs.get("default_ttl", None)
         self.endpoint = endpoint
         self.port = int(port)
         self.db = int(db)
@@ -111,6 +113,8 @@ class RedisBackend:
 
     @conn
     async def _set(self, key, value, ttl=None, _cas_token=None, _conn=None):
+        if ttl is None:
+            ttl = self.default_ttl
         if _cas_token is not None:
             return await self._cas(key, value, _cas_token, ttl=ttl, _conn=_conn)
         if ttl is None:
@@ -119,6 +123,8 @@ class RedisBackend:
 
     @conn
     async def _cas(self, key, value, token, ttl=None, _conn=None):
+        if ttl is None:
+            ttl = self.default_ttl
         args = [value, token]
         if ttl is not None:
             if isinstance(ttl, float):
@@ -130,6 +136,8 @@ class RedisBackend:
 
     @conn
     async def _multi_set(self, pairs, ttl=None, _conn=None):
+        if ttl is None:
+            ttl = self.default_ttl
         ttl = ttl or 0
 
         flattened = list(itertools.chain.from_iterable((key, value) for key, value in pairs))
@@ -150,6 +158,8 @@ class RedisBackend:
 
     @conn
     async def _add(self, key, value, ttl=None, _conn=None):
+        if ttl is None:
+            ttl = self.default_ttl
         expx = {"expire": ttl}
         if isinstance(ttl, float):
             expx = {"pexpire": int(ttl * 1000)}


### PR DESCRIPTION
This commit allow a default behavior to cache set functions

We could set this at config json, for example:
```
"cache": {
    "cache": "aiocache.SimpleMemoryCache",
    "default_ttl": 300,
    "serializer": {
        "class": "aiocache.serializers.PickleSerializer"
    }
},
```