### PR TITLE
fix: deletion of items that don't implement truthiness

### DIFF
--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -98,7 +98,7 @@ class SimpleMemoryBackend:
 
     @classmethod
     def __delete(cls, key):
-        if cls._cache.pop(key, None):
+        if cls._cache.pop(key, None) is not None:
             handle = cls._handlers.pop(key, None)
             if handle:
                 handle.cancel()


### PR DESCRIPTION
Example: pandas.DataFrame or pandas.Series.

The current memory backend implementation evaluates truthiness on deletion from the cache.

This works out most of the time but results in an error when caching pandas.Dataframe or pandas.Series objects.