### PR TITLE
Update docstring to match functionality

### DIFF
--- a/aiocache/backends/memory.py
+++ b/aiocache/backends/memory.py
@@ -110,7 +110,7 @@ class SimpleMemoryBackend:
 class SimpleMemoryCache(SimpleMemoryBackend, BaseCache):
     """
     Memory cache implementation with the following components as defaults:
-        - serializer: :class:`aiocache.serializers.JsonSerializer`
+        - serializer: :class:`aiocache.serializers.NullSerializer`
         - plugins: None
 
     Config options are:


### PR DESCRIPTION
To explain the default serializer for SimpleMemoryCache is the NullSerializer