### PR TITLE
Fix. Add kwargs to plugin methods.

### DIFF
--- a/aiocache/plugins.py
+++ b/aiocache/plugins.py
@@ -68,7 +68,7 @@ class HitMissRatioPlugin(BasePlugin):
     keys.
     """
 
-    async def post_get(self, client, key, took=0, ret=None):
+    async def post_get(self, client, key, took=0, ret=None, **kwargs):
         if not hasattr(client, "hit_miss_ratio"):
             client.hit_miss_ratio = {}
             client.hit_miss_ratio["total"] = 0
@@ -82,7 +82,7 @@ class HitMissRatioPlugin(BasePlugin):
             client.hit_miss_ratio["hits"] / client.hit_miss_ratio["total"]
         )
 
-    async def post_multi_get(self, client, keys, took=0, ret=None):
+    async def post_multi_get(self, client, keys, took=0, ret=None, **kwargs):
         if not hasattr(client, "hit_miss_ratio"):
             client.hit_miss_ratio = {}
             client.hit_miss_ratio["total"] = 0

--- a/tests/acceptance/test_plugins.py
+++ b/tests/acceptance/test_plugins.py
@@ -1,7 +1,6 @@
 import pytest
-
-from aiocache.plugins import HitMissRatioPlugin, TimingPlugin
 from aiocache.backends.memory import SimpleMemoryBackend
+from aiocache.plugins import HitMissRatioPlugin, TimingPlugin
 
 
 class TestHitMissRatioPlugin:
@@ -54,6 +53,21 @@ class TestHitMissRatioPlugin:
             memory_cache.hit_miss_ratio["hit_ratio"]
             == len(hits) / memory_cache.hit_miss_ratio["total"]
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "key,value,namespace", [("a", 1, None), ("b", 2, "test")],
+    )
+    async def test_set_and_get(self, memory_cache, key, value, namespace):
+        memory_cache.plugins = [HitMissRatioPlugin()]
+        if namespace is None:
+            await memory_cache.set(key, value)
+            result = await memory_cache.get(key)
+            assert result == value
+        else:
+            await memory_cache.set(key, value, namespace=namespace)
+            result = await memory_cache.get(key, namespace=namespace)
+            assert result == value
 
 
 class TestTimingPlugin:

--- a/tests/acceptance/test_plugins.py
+++ b/tests/acceptance/test_plugins.py
@@ -1,4 +1,5 @@
 import pytest
+
 from aiocache.backends.memory import SimpleMemoryBackend
 from aiocache.plugins import HitMissRatioPlugin, TimingPlugin
 
@@ -55,19 +56,14 @@ class TestHitMissRatioPlugin:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "key,value,namespace", [("a", 1, None), ("b", 2, "test")],
-    )
-    async def test_set_and_get(self, memory_cache, key, value, namespace):
+    async def test_set_and_get_using_namespace(self, memory_cache):
         memory_cache.plugins = [HitMissRatioPlugin()]
-        if namespace is None:
-            await memory_cache.set(key, value)
-            result = await memory_cache.get(key)
-            assert result == value
-        else:
-            await memory_cache.set(key, value, namespace=namespace)
-            result = await memory_cache.get(key, namespace=namespace)
-            assert result == value
+        key = "A"
+        namespace = "test"
+        value = 1
+        await memory_cache.set(key, value, namespace=namespace)
+        result = await memory_cache.get(key, namespace=namespace)
+        assert result == value
 
 
 class TestTimingPlugin:


### PR DESCRIPTION
It fixes next problem: if for example namespace parameter is passed to `get` method,  then `post_get` method raises unexpected keyword argument error.