### PR TITLE
fix: lint with local venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ cov-report = true
 
 
 lint:
-	flake8
+	flake8 tests/ aiocache/
 	black -l 100 --check tests/ aiocache/
 
 format:


### PR DESCRIPTION
Currently the `make lint` command will lint all installed packages
if using a local venv.

This commit changes the flake8 linter to be specific
(like the black formatter already is)