### PR TITLE
Add python3.8 support and remove python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,30 +12,14 @@ jobs:
   include:
     - stage: syntax
       script: tox
-      python: 3.6
+      python: 3.8
       env: TOXENV=syntax
     - script: tox
-      python: 3.6
+      python: 3.8
       env: TOXENV=docs-html
 
     - stage: test
       script: tox
-      env: TOXENV=py35,codecov
-      python: 3.5
-    - script: tox
-      env: TOXENV=py35,codecov
-      python: 3.5-dev
-    - script: tox
-      env: TOXENV=py35-ujson,codecov
-      python: 3.5
-    - script: tox
-      env: TOXENV=py35-deps-lowest,codecov
-      python: 3.5
-    - script: tox
-      env: TOXENV=py35-deps-devel,codecov
-      python: 3.5
-
-    - script: tox
       env: TOXENV=py36,codecov
       python: 3.6
     - script: tox
@@ -72,9 +56,25 @@ jobs:
       dist: xenial
       sudo: true
 
+    - script: tox
+      env: TOXENV=py38,codecov
+      python: 3.8
+    - script: tox
+      env: TOXENV=py38,codecov
+      python: 3.8-dev
+    - script: tox
+      env: TOXENV=py38-ujson,codecov
+      python: 3.8
+    - script: tox
+      env: TOXENV=py38-deps-lowest,codecov
+      python: 3.8
+    - script: tox
+      env: TOXENV=py38-deps-devel,codecov
+      python: 3.8
+
     - stage: deploy
       script: skip
-      python: 3.6
+      python: 3.8
       deploy: &pypi
         provider: pypi
         user: blck
@@ -83,4 +83,4 @@ jobs:
         distributions: "sdist bdist_wheel"
         on:
           tags: true
-          python: 3.6
+          python: 3.8

--- a/aiocache/decorators.py
+++ b/aiocache/decorators.py
@@ -338,7 +338,7 @@ class multi_cached:
 
     def get_cache_keys(self, f, args, kwargs):
         args_dict = _get_args_dict(f, args, kwargs)
-        keys = args_dict[self.keys_from_attr] or []
+        keys = args_dict.get(self.keys_from_attr, []) or []
         keys = [self.key_builder(key, f, *args, **kwargs) for key in keys]
 
         args_names = f.__code__.co_varnames[: f.__code__.co_argcount]

--- a/aiocache/serializers/serializers.py
+++ b/aiocache/serializers/serializers.py
@@ -99,6 +99,10 @@ class PickleSerializer(BaseSerializer):
 
     DEFAULT_ENCODING = None
 
+    def __init__(self, *args, protocol=pickle.DEFAULT_PROTOCOL, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.protocol = protocol
+
     def dumps(self, value):
         """
         Serialize the received value using ``pickle.dumps``.
@@ -106,7 +110,7 @@ class PickleSerializer(BaseSerializer):
         :param value: obj
         :returns: bytes
         """
-        return pickle.dumps(value)
+        return pickle.dumps(value, protocol=self.protocol)
 
     def loads(self, value):
         """

--- a/setup.py
+++ b/setup.py
@@ -28,16 +28,17 @@ setup(
     long_description=readme,
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: AsyncIO',
     ],
     packages=find_packages(),
     install_requires=None,
     extras_require={
         'redis:python_version<"3.7"': ['aioredis>=0.3.3'],
-        'redis:python_version>="3.7"': ['aioredis>=1.0.0'],
+        'redis:python_version>="3.8"': ['aioredis>=1.3.0'],
+        'redis:python_version>="3.7" and python_version<"3.8"': ['aioredis>=1.0.0'],
         'memcached': ['aiomcache>=0.5.2'],
         'msgpack': ['msgpack>=0.5.5'],
         'dev': [

--- a/tests/ut/test_decorators.py
+++ b/tests/ut/test_decorators.py
@@ -414,8 +414,7 @@ class TestMultiCached:
         assert decorator.get_cache_keys(stub_dict, (), {"keys": []}) == ([], [], -1)
 
     def test_get_cache_keys_missing_kwarg(self, decorator):
-        with pytest.raises(KeyError):
-            assert decorator.get_cache_keys(stub_dict, (), {})
+        assert decorator.get_cache_keys(stub_dict, (), {}) == ([], [], -1)
 
     def test_get_cache_keys_arg_key_from_attr(self, decorator):
         def fake(keys, a=1, b=2):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-  py{36,37}-{deps-lowest,deps-devel}
-  py{35,36,37}-ujson
+  py{36,37,38}-{deps-lowest,deps-devel}
+  py{36,37,38}-ujson
   codecov
   syntax
   docs-html
@@ -14,6 +14,7 @@ whitelist_externals =
   bash
 
 deps =
+  py38-deps-lowest: aioredis==1.3.0
   py37-deps-lowest: aioredis==1.0.0
   py36-deps-lowest: aioredis==0.3.3
   deps-lowest: aiomcache==0.5.2


### PR DESCRIPTION
Aioredis python3.8 support starts at version 1.3.0 at least for the functionalities the package uses so restricting that